### PR TITLE
Fix sort locale fallback

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,10 @@ def sort_packages(packages: List[str], locale_: Optional[str] = None) -> List[st
         try:
             with set_locale(locale_) as strcoll:
                 return sorted(packages, key=cmp_to_key(strcoll))
-        except locale.Error:
+        except locale.Error as e:
+            logging.warning(
+                f"Locale error encountered with locale '{locale_}': {e}. Falling back to default sorting."
+            )
             return sorted(packages)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -28,8 +28,11 @@ def sort_packages(packages: List[str], locale_: Optional[str] = None) -> List[st
     if locale_ is None:
         return sorted(packages)
     else:
-        with set_locale(locale_) as strcoll:
-            return sorted(packages, key=cmp_to_key(strcoll))
+        try:
+            with set_locale(locale_) as strcoll:
+                return sorted(packages, key=cmp_to_key(strcoll))
+        except locale.Error:
+            return sorted(packages)
 
 
 def gather_requirements_files(paths: List[pathlib.Path]) -> List[pathlib.Path]:


### PR DESCRIPTION
## Summary
- avoid crashing when requested locale is not installed by falling back to default sorting

## Testing
- `make lint`
- `make type` *(fails: tests/conftest.py:10: error: The return type of a generator function should be "Generator" or one of its supertypes)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685cc5d310cc83299c2eeb1f39204d65