### PR TITLE
Configure setuptools for src layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ license = {text = "MIT"}
 requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+package-dir = {"" = "src"}
+py-modules = ["main"]
+
 
 [tool.pdm]
 package-type = "library"


### PR DESCRIPTION
## Summary
- specify `src` layout in setuptools configuration
- revert accidental locale changes from previous commit

## Testing
- `pytest -q` *(fails: unsupported locale setting)*

------
https://chatgpt.com/codex/tasks/task_e_686306b0a5a88329a92229cdeaf86c00