### PR TITLE
Add configurable PyPI index URLs with fallback support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ just type       # Run ty type checker
 
 ## Testing Guidelines
 
-- **Prefer test functions over test classes**: Use standalone test functions unless grouping related scenarios with shared fixtures.
+- **Use standalone test functions**: Do not use test classes. Organize tests by naming convention (e.g., `test_<feature>_<scenario>`) and use shared fixtures from `conftest.py` instead of class-based grouping.
 - **Use pytest.parametrize**: For multiple inputs or scenarios, use `@pytest.mark.parametrize` instead of multiple assertions or separate test functions.
 - **Use pyfakefs**: For filesystem tests, use fixtures from `conftest.py` (e.g., `single_requirements_file`, `fs`) not `tempfile`.
 - **Test organization**: Unit tests in `tests/unit/`, integration tests in `tests/integration/`.
@@ -50,6 +50,7 @@ just type       # Run ty type checker
 
 ## Avoid
 
+- Don't use test classes—use standalone test functions with descriptive names
 - Don't use `tempfile` for tests—use pyfakefs fixtures
 - Don't add commands without `--preview` support
 - Don't hardcode colors—use the theme in `console.py`

--- a/README.md
+++ b/README.md
@@ -296,13 +296,25 @@ The CLI supports a configuration file stored in your home directory at `~/.requi
 requirements config init
 ```
 
-**Set color preference:**
+**Set configuration values:**
 ```bash
 # Enable colors
-requirements config set color true
+requirements config set color.enabled true
 
 # Disable colors
-requirements config set color false
+requirements config set color.enabled false
+
+# Set custom PyPI index URL
+requirements config set pypi.index_url https://nexus.example.com/simple/
+
+# Set fallback URL (used when primary fails)
+requirements config set pypi.fallback_url https://pypi.org/simple/
+```
+
+**Remove configuration values (reset to default):**
+```bash
+requirements config unset pypi.index_url
+requirements config unset color.enabled
 ```
 
 **View current settings:**
@@ -315,11 +327,27 @@ requirements config show
 requirements config path
 ```
 
+**Available settings:**
+| Setting | Type | Description |
+|---------|------|-------------|
+| `color.enabled` | bool | Enable/disable colored output |
+| `pypi.index_url` | URL | Primary PyPI index URL for version queries |
+| `pypi.fallback_url` | URL | Fallback URL if primary fails (network errors only) |
+
 **Example config file (`~/.requirements/config.toml`):**
 ```toml
 [color]
 enabled = true
+
+[pypi]
+index_url = "https://nexus.example.com/simple/"
+fallback_url = "https://pypi.org/simple/"
 ```
+
+**Index URL priority:**
+1. `--index-url` flag (highest priority)
+2. Config `pypi.index_url`
+3. Default PyPI (`https://pypi.org/simple/`)
 
 ### Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "requirements-cli"
-version = "0.2.0"
+version = "0.3.0"
 description = "Cli tool to update requirements.txt files in a mono repo style project."
 authors = [
     {name = "Jason", email = "5758786+CaptainDriftwood@users.noreply.github.com"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,40 @@
 import pathlib
 from collections.abc import Generator
+from unittest.mock import MagicMock
 
 import pytest
 from click.testing import CliRunner
 from pyfakefs.fake_filesystem import FakeFilesystem
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def cli_runner() -> Generator[CliRunner, None, None]:
+    """Reusable CLI runner for all tests."""
     yield CliRunner()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def requirements_txt() -> bytes:
     return b"pytest\nboto3~=1.0.0\nenhancement-models==1.0.0\n"
+
+
+@pytest.fixture(scope="session")
+def requests_simple_html() -> str:
+    """Load the requests package Simple API HTML fixture."""
+    fixture_path = (
+        pathlib.Path(__file__).parent / "fixtures" / "pypi_simple_requests.html"
+    )
+    return fixture_path.read_text()
+
+
+@pytest.fixture
+def mock_pypi_response(requests_simple_html: str) -> MagicMock:
+    """Create a mock urllib response for PyPI Simple API tests."""
+    mock_response = MagicMock()
+    mock_response.read.return_value = requests_simple_html.encode("utf-8")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+    return mock_response
 
 
 @pytest.fixture
@@ -71,6 +92,14 @@ def single_requirements_file_with_aws_sam_build_directory(
 
 
 @pytest.fixture
+def fake_home(fs: FakeFilesystem) -> pathlib.Path:
+    """Create a fake home directory for config tests."""
+    home = pathlib.Path("/fake/home")
+    home.mkdir(parents=True)
+    return home
+
+
+@pytest.fixture(scope="session")
 def requirements_txt_with_comments() -> bytes:
     """Requirements file with comments and blank lines"""
     return b"""# Production dependencies
@@ -86,7 +115,7 @@ black==21.0.0
 """
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def complex_requirements_txt() -> bytes:
     """Complex requirements file with various package formats"""
     return b"""# Main dependencies

--- a/tests/integration/test_add.py
+++ b/tests/integration/test_add.py
@@ -5,69 +5,68 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 
 from requirements.main import add_package
 
+# =============================================================================
+# add_package tests
+# =============================================================================
 
-class TestAddPackage:
-    """Test add_package functionality"""
 
-    def test_add_new_package(
-        self, cli_runner: CliRunner, single_requirements_file: str
-    ) -> None:
-        """Test adding a new package to requirements.txt"""
-        result = cli_runner.invoke(add_package, ["requests", single_requirements_file])
-        assert result.exit_code == 0
+def test_add_new_package(cli_runner: CliRunner, single_requirements_file: str) -> None:
+    """Test adding a new package to requirements.txt"""
+    result = cli_runner.invoke(add_package, ["requests", single_requirements_file])
+    assert result.exit_code == 0
+    contents = (pathlib.Path(single_requirements_file) / "requirements.txt").read_text()
+    assert "requests" in contents
+    assert "boto3~=1.0.0" in contents
+    assert "enhancement-models==1.0.0" in contents
+    assert "pytest" in contents
+
+
+def test_add_existing_package(
+    cli_runner: CliRunner, single_requirements_file: str
+) -> None:
+    """Test adding an existing package to requirements.txt"""
+    result = cli_runner.invoke(add_package, ["pytest", single_requirements_file])
+    assert result.exit_code == 0
+    assert "pytest already exists" in result.output
+    contents = (pathlib.Path(single_requirements_file) / "requirements.txt").read_text()
+    assert contents == "pytest\nboto3~=1.0.0\nenhancement-models==1.0.0\n"
+
+
+def test_add_package_with_preview(
+    cli_runner: CliRunner, single_requirements_file: str
+) -> None:
+    """Test adding a package with preview flag"""
+    result = cli_runner.invoke(
+        add_package, ["requests", single_requirements_file, "--preview"]
+    )
+    assert result.exit_code == 0
+    assert "Previewing changes" in result.output
+    assert "requests" in result.output
+
+    # Verify file unchanged
+    contents = (pathlib.Path(single_requirements_file) / "requirements.txt").read_text()
+    assert contents == "pytest\nboto3~=1.0.0\nenhancement-models==1.0.0\n"
+
+
+def test_add_package_multiple_files(
+    cli_runner: CliRunner, multiple_nested_directories: str
+) -> None:
+    """Test adding a package to multiple requirements files"""
+    result = cli_runner.invoke(add_package, ["requests", multiple_nested_directories])
+    assert result.exit_code == 0
+
+    for i in range(3):
         contents = (
-            pathlib.Path(single_requirements_file) / "requirements.txt"
+            pathlib.Path(multiple_nested_directories)
+            / f"directory{i}"
+            / "requirements.txt"
         ).read_text()
         assert "requests" in contents
-        assert "boto3~=1.0.0" in contents
-        assert "enhancement-models==1.0.0" in contents
-        assert "pytest" in contents
 
-    def test_add_existing_package(
-        self, cli_runner: CliRunner, single_requirements_file: str
-    ) -> None:
-        """Test adding an existing package to requirements.txt"""
-        result = cli_runner.invoke(add_package, ["pytest", single_requirements_file])
-        assert result.exit_code == 0
-        assert "pytest already exists" in result.output
-        contents = (
-            pathlib.Path(single_requirements_file) / "requirements.txt"
-        ).read_text()
-        assert contents == "pytest\nboto3~=1.0.0\nenhancement-models==1.0.0\n"
 
-    def test_add_package_with_preview(
-        self, cli_runner: CliRunner, single_requirements_file: str
-    ) -> None:
-        """Test adding a package with preview flag"""
-        result = cli_runner.invoke(
-            add_package, ["requests", single_requirements_file, "--preview"]
-        )
-        assert result.exit_code == 0
-        assert "Previewing changes" in result.output
-        assert "requests" in result.output
-
-        # Verify file unchanged
-        contents = (
-            pathlib.Path(single_requirements_file) / "requirements.txt"
-        ).read_text()
-        assert contents == "pytest\nboto3~=1.0.0\nenhancement-models==1.0.0\n"
-
-    def test_add_package_multiple_files(
-        self, cli_runner: CliRunner, multiple_nested_directories: str
-    ) -> None:
-        """Test adding a package to multiple requirements files"""
-        result = cli_runner.invoke(
-            add_package, ["requests", multiple_nested_directories]
-        )
-        assert result.exit_code == 0
-
-        for i in range(3):
-            contents = (
-                pathlib.Path(multiple_nested_directories)
-                / f"directory{i}"
-                / "requirements.txt"
-            ).read_text()
-            assert "requests" in contents
+# =============================================================================
+# Inline comments tests
+# =============================================================================
 
 
 def test_add_package_preserves_inline_comments(

--- a/tests/integration/test_config_commands.py
+++ b/tests/integration/test_config_commands.py
@@ -1,0 +1,166 @@
+"""Integration tests for config commands."""
+
+import pathlib
+
+from click.testing import CliRunner
+
+from requirements.main import cli
+
+
+class TestConfigSetCommand:
+    """Tests for config set command."""
+
+    def test_config_set_color_enabled(
+        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+    ) -> None:
+        """Test setting color.enabled to true."""
+        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+        result = cli_runner.invoke(cli, ["config", "set", "color.enabled", "true"])
+
+        assert result.exit_code == 0
+        assert "color.enabled enabled" in result.output
+
+    def test_config_set_color_disabled(
+        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+    ) -> None:
+        """Test setting color.enabled to false."""
+        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+        result = cli_runner.invoke(cli, ["config", "set", "color.enabled", "false"])
+
+        assert result.exit_code == 0
+        assert "color.enabled disabled" in result.output
+
+    def test_config_set_pypi_index_url(
+        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+    ) -> None:
+        """Test setting pypi.index_url."""
+        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+        result = cli_runner.invoke(
+            cli,
+            ["config", "set", "pypi.index_url", "https://nexus.example.com/simple/"],
+        )
+
+        assert result.exit_code == 0
+        assert "pypi.index_url = https://nexus.example.com/simple/" in result.output
+
+    def test_config_set_pypi_fallback_url(
+        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+    ) -> None:
+        """Test setting pypi.fallback_url."""
+        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+        result = cli_runner.invoke(
+            cli, ["config", "set", "pypi.fallback_url", "https://pypi.org/simple/"]
+        )
+
+        assert result.exit_code == 0
+        assert "pypi.fallback_url = https://pypi.org/simple/" in result.output
+
+    def test_config_set_invalid_url(
+        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+    ) -> None:
+        """Test setting pypi.index_url with invalid URL."""
+        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+        result = cli_runner.invoke(
+            cli, ["config", "set", "pypi.index_url", "not-a-url"]
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid URL" in result.output
+        assert "http://" in result.output or "https://" in result.output
+
+    def test_config_set_invalid_setting(
+        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+    ) -> None:
+        """Test setting an unknown setting."""
+        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+        result = cli_runner.invoke(cli, ["config", "set", "invalid.setting", "value"])
+
+        assert result.exit_code == 1
+        assert "Unknown setting" in result.output
+
+    def test_config_set_invalid_bool_value(
+        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+    ) -> None:
+        """Test setting color.enabled with invalid boolean."""
+        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+        result = cli_runner.invoke(cli, ["config", "set", "color.enabled", "maybe"])
+
+        assert result.exit_code == 1
+        assert "Invalid boolean" in result.output
+
+
+class TestConfigUnsetCommand:
+    """Tests for config unset command."""
+
+    def test_config_unset_existing_setting(
+        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+    ) -> None:
+        """Test unsetting an existing setting."""
+        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+        # First set a value
+        cli_runner.invoke(
+            cli,
+            ["config", "set", "pypi.index_url", "https://nexus.example.com/simple/"],
+        )
+
+        # Then unset it
+        result = cli_runner.invoke(cli, ["config", "unset", "pypi.index_url"])
+
+        assert result.exit_code == 0
+        assert "Removed pypi.index_url" in result.output
+
+    def test_config_unset_nonexistent_setting(
+        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+    ) -> None:
+        """Test unsetting a setting that doesn't exist."""
+        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+        result = cli_runner.invoke(cli, ["config", "unset", "pypi.index_url"])
+
+        assert result.exit_code == 0
+        assert "was not set" in result.output
+
+    def test_config_unset_invalid_setting(
+        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+    ) -> None:
+        """Test unsetting an unknown setting."""
+        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+        result = cli_runner.invoke(cli, ["config", "unset", "invalid.setting"])
+
+        assert result.exit_code == 1
+        assert "Unknown setting" in result.output
+
+
+class TestConfigShowCommand:
+    """Tests for config show command with new settings."""
+
+    def test_config_show_displays_pypi_settings(
+        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+    ) -> None:
+        """Test that config show displays pypi settings."""
+        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+        # Set pypi settings
+        cli_runner.invoke(
+            cli,
+            ["config", "set", "pypi.index_url", "https://nexus.example.com/simple/"],
+        )
+        cli_runner.invoke(
+            cli, ["config", "set", "pypi.fallback_url", "https://pypi.org/simple/"]
+        )
+
+        result = cli_runner.invoke(cli, ["config", "show"])
+
+        assert result.exit_code == 0
+        assert "pypi.index_url" in result.output
+        assert "pypi.fallback_url" in result.output
+        assert "nexus.example.com" in result.output

--- a/tests/integration/test_config_commands.py
+++ b/tests/integration/test_config_commands.py
@@ -6,161 +6,172 @@ from click.testing import CliRunner
 
 from requirements.main import cli
 
-
-class TestConfigSetCommand:
-    """Tests for config set command."""
-
-    def test_config_set_color_enabled(
-        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
-    ) -> None:
-        """Test setting color.enabled to true."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
-
-        result = cli_runner.invoke(cli, ["config", "set", "color.enabled", "true"])
-
-        assert result.exit_code == 0
-        assert "color.enabled enabled" in result.output
-
-    def test_config_set_color_disabled(
-        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
-    ) -> None:
-        """Test setting color.enabled to false."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
-
-        result = cli_runner.invoke(cli, ["config", "set", "color.enabled", "false"])
-
-        assert result.exit_code == 0
-        assert "color.enabled disabled" in result.output
-
-    def test_config_set_pypi_index_url(
-        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
-    ) -> None:
-        """Test setting pypi.index_url."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
-
-        result = cli_runner.invoke(
-            cli,
-            ["config", "set", "pypi.index_url", "https://nexus.example.com/simple/"],
-        )
-
-        assert result.exit_code == 0
-        assert "pypi.index_url = https://nexus.example.com/simple/" in result.output
-
-    def test_config_set_pypi_fallback_url(
-        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
-    ) -> None:
-        """Test setting pypi.fallback_url."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
-
-        result = cli_runner.invoke(
-            cli, ["config", "set", "pypi.fallback_url", "https://pypi.org/simple/"]
-        )
-
-        assert result.exit_code == 0
-        assert "pypi.fallback_url = https://pypi.org/simple/" in result.output
-
-    def test_config_set_invalid_url(
-        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
-    ) -> None:
-        """Test setting pypi.index_url with invalid URL."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
-
-        result = cli_runner.invoke(
-            cli, ["config", "set", "pypi.index_url", "not-a-url"]
-        )
-
-        assert result.exit_code == 1
-        assert "Invalid URL" in result.output
-        assert "http://" in result.output or "https://" in result.output
-
-    def test_config_set_invalid_setting(
-        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
-    ) -> None:
-        """Test setting an unknown setting."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
-
-        result = cli_runner.invoke(cli, ["config", "set", "invalid.setting", "value"])
-
-        assert result.exit_code == 1
-        assert "Unknown setting" in result.output
-
-    def test_config_set_invalid_bool_value(
-        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
-    ) -> None:
-        """Test setting color.enabled with invalid boolean."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
-
-        result = cli_runner.invoke(cli, ["config", "set", "color.enabled", "maybe"])
-
-        assert result.exit_code == 1
-        assert "Invalid boolean" in result.output
+# =============================================================================
+# config set tests
+# =============================================================================
 
 
-class TestConfigUnsetCommand:
-    """Tests for config unset command."""
+def test_config_set_color_enabled(
+    cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+) -> None:
+    """Test setting color.enabled to true."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
 
-    def test_config_unset_existing_setting(
-        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
-    ) -> None:
-        """Test unsetting an existing setting."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+    result = cli_runner.invoke(cli, ["config", "set", "color.enabled", "true"])
 
-        # First set a value
-        cli_runner.invoke(
-            cli,
-            ["config", "set", "pypi.index_url", "https://nexus.example.com/simple/"],
-        )
-
-        # Then unset it
-        result = cli_runner.invoke(cli, ["config", "unset", "pypi.index_url"])
-
-        assert result.exit_code == 0
-        assert "Removed pypi.index_url" in result.output
-
-    def test_config_unset_nonexistent_setting(
-        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
-    ) -> None:
-        """Test unsetting a setting that doesn't exist."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
-
-        result = cli_runner.invoke(cli, ["config", "unset", "pypi.index_url"])
-
-        assert result.exit_code == 0
-        assert "was not set" in result.output
-
-    def test_config_unset_invalid_setting(
-        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
-    ) -> None:
-        """Test unsetting an unknown setting."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
-
-        result = cli_runner.invoke(cli, ["config", "unset", "invalid.setting"])
-
-        assert result.exit_code == 1
-        assert "Unknown setting" in result.output
+    assert result.exit_code == 0
+    assert "color.enabled enabled" in result.output
 
 
-class TestConfigShowCommand:
-    """Tests for config show command with new settings."""
+def test_config_set_color_disabled(
+    cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+) -> None:
+    """Test setting color.enabled to false."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
 
-    def test_config_show_displays_pypi_settings(
-        self, cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
-    ) -> None:
-        """Test that config show displays pypi settings."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+    result = cli_runner.invoke(cli, ["config", "set", "color.enabled", "false"])
 
-        # Set pypi settings
-        cli_runner.invoke(
-            cli,
-            ["config", "set", "pypi.index_url", "https://nexus.example.com/simple/"],
-        )
-        cli_runner.invoke(
-            cli, ["config", "set", "pypi.fallback_url", "https://pypi.org/simple/"]
-        )
+    assert result.exit_code == 0
+    assert "color.enabled disabled" in result.output
 
-        result = cli_runner.invoke(cli, ["config", "show"])
 
-        assert result.exit_code == 0
-        assert "pypi.index_url" in result.output
-        assert "pypi.fallback_url" in result.output
-        assert "nexus.example.com" in result.output
+def test_config_set_pypi_index_url(
+    cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+) -> None:
+    """Test setting pypi.index_url."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    result = cli_runner.invoke(
+        cli,
+        ["config", "set", "pypi.index_url", "https://nexus.example.com/simple/"],
+    )
+
+    assert result.exit_code == 0
+    assert "pypi.index_url = https://nexus.example.com/simple/" in result.output
+
+
+def test_config_set_pypi_fallback_url(
+    cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+) -> None:
+    """Test setting pypi.fallback_url."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    result = cli_runner.invoke(
+        cli, ["config", "set", "pypi.fallback_url", "https://pypi.org/simple/"]
+    )
+
+    assert result.exit_code == 0
+    assert "pypi.fallback_url = https://pypi.org/simple/" in result.output
+
+
+def test_config_set_invalid_url(
+    cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+) -> None:
+    """Test setting pypi.index_url with invalid URL."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    result = cli_runner.invoke(cli, ["config", "set", "pypi.index_url", "not-a-url"])
+
+    assert result.exit_code == 1
+    assert "Invalid URL" in result.output
+    assert "http://" in result.output or "https://" in result.output
+
+
+def test_config_set_invalid_setting(
+    cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+) -> None:
+    """Test setting an unknown setting."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    result = cli_runner.invoke(cli, ["config", "set", "invalid.setting", "value"])
+
+    assert result.exit_code == 1
+    assert "Unknown setting" in result.output
+
+
+def test_config_set_invalid_bool_value(
+    cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+) -> None:
+    """Test setting color.enabled with invalid boolean."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    result = cli_runner.invoke(cli, ["config", "set", "color.enabled", "maybe"])
+
+    assert result.exit_code == 1
+    assert "Invalid boolean" in result.output
+
+
+# =============================================================================
+# config unset tests
+# =============================================================================
+
+
+def test_config_unset_existing_setting(
+    cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+) -> None:
+    """Test unsetting an existing setting."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    # First set a value
+    cli_runner.invoke(
+        cli,
+        ["config", "set", "pypi.index_url", "https://nexus.example.com/simple/"],
+    )
+
+    # Then unset it
+    result = cli_runner.invoke(cli, ["config", "unset", "pypi.index_url"])
+
+    assert result.exit_code == 0
+    assert "Removed pypi.index_url" in result.output
+
+
+def test_config_unset_nonexistent_setting(
+    cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+) -> None:
+    """Test unsetting a setting that doesn't exist."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    result = cli_runner.invoke(cli, ["config", "unset", "pypi.index_url"])
+
+    assert result.exit_code == 0
+    assert "was not set" in result.output
+
+
+def test_config_unset_invalid_setting(
+    cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+) -> None:
+    """Test unsetting an unknown setting."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    result = cli_runner.invoke(cli, ["config", "unset", "invalid.setting"])
+
+    assert result.exit_code == 1
+    assert "Unknown setting" in result.output
+
+
+# =============================================================================
+# config show tests
+# =============================================================================
+
+
+def test_config_show_displays_pypi_settings(
+    cli_runner: CliRunner, fake_home: pathlib.Path, monkeypatch
+) -> None:
+    """Test that config show displays pypi settings."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    # Set pypi settings
+    cli_runner.invoke(
+        cli,
+        ["config", "set", "pypi.index_url", "https://nexus.example.com/simple/"],
+    )
+    cli_runner.invoke(
+        cli, ["config", "set", "pypi.fallback_url", "https://pypi.org/simple/"]
+    )
+
+    result = cli_runner.invoke(cli, ["config", "show"])
+
+    assert result.exit_code == 0
+    assert "pypi.index_url" in result.output
+    assert "pypi.fallback_url" in result.output
+    assert "nexus.example.com" in result.output

--- a/tests/integration/test_file_existence_validation.py
+++ b/tests/integration/test_file_existence_validation.py
@@ -13,266 +13,276 @@ from requirements.main import (
     update_package,
 )
 
-
-class TestGatherRequirementsFilesValidation:
-    """Test file existence validation in gather_requirements_files function"""
-
-    def test_nonexistent_path(self, capsys, fs: FakeFilesystem):
-        """Test handling of non-existent paths"""
-        nonexistent_path = pathlib.Path("/this/path/does/not/exist")
-        result = gather_requirements_files([nonexistent_path])
-
-        assert result == []
-        captured = capsys.readouterr()
-        assert "Error: Path '/this/path/does/not/exist' does not exist" in captured.err
-
-    def test_wrong_filename(self, capsys, fs: FakeFilesystem):
-        """Test handling of files that aren't named requirements.txt"""
-        tmp_path = pathlib.Path("/fake/wrong-filename")
-        tmp_path.mkdir(parents=True)
-        wrong_file = tmp_path / "dependencies.txt"
-        wrong_file.write_text("requests==2.26.0\n")
-
-        result = gather_requirements_files([wrong_file])
-
-        assert result == []
-        captured = capsys.readouterr()
-        assert (
-            "is not a requirements.txt file (found: dependencies.txt)" in captured.err
-        )
-
-    def test_valid_requirements_file(self, fs: FakeFilesystem):
-        """Test handling of valid requirements.txt file"""
-        tmp_path = pathlib.Path("/fake/valid-file")
-        tmp_path.mkdir(parents=True)
-        req_file = tmp_path / "requirements.txt"
-        req_file.write_text("requests==2.26.0\n")
-
-        result = gather_requirements_files([req_file])
-
-        assert result == [req_file]
-
-    def test_directory_with_no_requirements_files(self, capsys, fs: FakeFilesystem):
-        """Test handling of directory with no requirements.txt files"""
-        tmp_path = pathlib.Path("/fake/no-reqs")
-        tmp_path.mkdir(parents=True)
-        empty_dir = tmp_path / "empty"
-        empty_dir.mkdir()
-
-        result = gather_requirements_files([empty_dir])
-
-        assert result == []
-        captured = capsys.readouterr()
-        assert (
-            f"Warning: No requirements.txt files found in directory '{empty_dir}'"
-            in captured.err
-        )
-
-    def test_directory_with_requirements_files(self, fs: FakeFilesystem):
-        """Test handling of directory with requirements.txt files"""
-        tmp_path = pathlib.Path("/fake/with-reqs")
-        tmp_path.mkdir(parents=True)
-        req_file = tmp_path / "requirements.txt"
-        req_file.write_text("requests==2.26.0\n")
-
-        result = gather_requirements_files([tmp_path])
-
-        assert req_file in result
-
-    def test_mixed_valid_and_invalid_paths(self, capsys, fs: FakeFilesystem):
-        """Test handling mix of valid and invalid paths"""
-        tmp_path = pathlib.Path("/fake/mixed-paths")
-        tmp_path.mkdir(parents=True)
-        # Valid file
-        req_file = tmp_path / "requirements.txt"
-        req_file.write_text("requests==2.26.0\n")
-
-        # Invalid file
-        wrong_file = tmp_path / "dependencies.txt"
-        wrong_file.write_text("django==3.2.0\n")
-
-        # Non-existent path
-        nonexistent_path = tmp_path / "nonexistent"
-
-        result = gather_requirements_files([req_file, wrong_file, nonexistent_path])
-
-        assert result == [req_file]
-        captured = capsys.readouterr()
-        assert "is not a requirements.txt file" in captured.err
-        assert "does not exist" in captured.err
-
-    def test_venv_exclusion_still_works(self, fs: FakeFilesystem):
-        """Test that virtual environment exclusion still works"""
-        tmp_path = pathlib.Path("/fake/venv-exclusion")
-        tmp_path.mkdir(parents=True)
-        # Create a venv directory with requirements.txt
-        venv_dir = tmp_path / "venv"
-        venv_dir.mkdir()
-        venv_req = venv_dir / "requirements.txt"
-        venv_req.write_text("should-be-excluded==1.0.0\n")
-
-        # Create a normal requirements.txt
-        normal_req = tmp_path / "requirements.txt"
-        normal_req.write_text("should-be-included==1.0.0\n")
-
-        result = gather_requirements_files([tmp_path])
-
-        assert normal_req in result
-        assert venv_req not in result
+# =============================================================================
+# gather_requirements_files validation tests
+# =============================================================================
 
 
-class TestCommandFileValidation:
-    """Test that all commands handle missing files gracefully"""
+def test_gather_nonexistent_path(capsys, fs: FakeFilesystem):
+    """Test handling of non-existent paths"""
+    nonexistent_path = pathlib.Path("/this/path/does/not/exist")
+    result = gather_requirements_files([nonexistent_path])
 
-    def test_find_command_nonexistent_file(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test find command with non-existent file"""
-        result = cli_runner.invoke(find_package, ["django", "/nonexistent/path"])
-
-        assert result.exit_code == 0  # Should not crash
-        assert "Error: Path '/nonexistent/path' does not exist" in result.output
-
-    def test_add_command_nonexistent_file(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test add command with non-existent file"""
-        result = cli_runner.invoke(add_package, ["django", "/nonexistent/path"])
-
-        assert result.exit_code == 0  # Should not crash
-        assert "Error: Path '/nonexistent/path' does not exist" in result.output
-
-    def test_remove_command_nonexistent_file(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test remove command with non-existent file"""
-        result = cli_runner.invoke(remove_package, ["django", "/nonexistent/path"])
-
-        assert result.exit_code == 0  # Should not crash
-        assert "Error: Path '/nonexistent/path' does not exist" in result.output
-
-    def test_update_command_nonexistent_file(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test update command with non-existent file"""
-        result = cli_runner.invoke(
-            update_package, ["django", "4.2.0", "/nonexistent/path"]
-        )
-
-        assert result.exit_code == 0  # Should not crash
-        assert "Error: Path '/nonexistent/path' does not exist" in result.output
-
-    def test_sort_command_nonexistent_file(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test sort command with non-existent file"""
-        result = cli_runner.invoke(sort_requirements, ["/nonexistent/path"])
-
-        assert result.exit_code == 0  # Should not crash
-        assert "Error: Path '/nonexistent/path' does not exist" in result.output
-
-    def test_cat_command_nonexistent_file(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test cat command with non-existent file"""
-        result = cli_runner.invoke(cat_requirements, ["/nonexistent/path"])
-
-        assert result.exit_code == 0  # Should not crash
-        assert "Error: Path '/nonexistent/path' does not exist" in result.output
-
-    def test_wrong_filename_error_messages(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test clear error messages for wrong filenames"""
-        tmp_path = pathlib.Path("/fake/cmd-wrong-filename")
-        tmp_path.mkdir(parents=True)
-        wrong_file = tmp_path / "dependencies.txt"
-        wrong_file.write_text("requests==2.26.0\n")
-
-        result = cli_runner.invoke(find_package, ["django", str(wrong_file)])
-
-        assert result.exit_code == 0
-        assert (
-            "is not a requirements.txt file (found: dependencies.txt)" in result.output
-        )
-
-    def test_empty_directory_warning(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test warning for empty directories"""
-        tmp_path = pathlib.Path("/fake/cmd-empty-dir")
-        tmp_path.mkdir(parents=True)
-        empty_dir = tmp_path / "empty"
-        empty_dir.mkdir()
-
-        result = cli_runner.invoke(find_package, ["django", str(empty_dir)])
-
-        assert result.exit_code == 0
-        assert (
-            f"Warning: No requirements.txt files found in directory '{empty_dir}'"
-            in result.output
-        )
+    assert result == []
+    captured = capsys.readouterr()
+    assert "Error: Path '/this/path/does/not/exist' does not exist" in captured.err
 
 
-class TestEdgeCases:
-    """Test edge cases in file validation"""
+def test_gather_wrong_filename(capsys, fs: FakeFilesystem):
+    """Test handling of files that aren't named requirements.txt"""
+    tmp_path = pathlib.Path("/fake/wrong-filename")
+    tmp_path.mkdir(parents=True)
+    wrong_file = tmp_path / "dependencies.txt"
+    wrong_file.write_text("requests==2.26.0\n")
 
-    def test_file_deleted_between_glob_and_access(
-        self, monkeypatch, fs: FakeFilesystem
-    ):
-        """Test handling of files deleted between directory scan and file access"""
-        tmp_path = pathlib.Path("/fake/file-deleted")
-        tmp_path.mkdir(parents=True)
-        # Create a requirements.txt file
-        req_file = tmp_path / "requirements.txt"
-        req_file.write_text("requests==2.26.0\n")
+    result = gather_requirements_files([wrong_file])
 
-        # Mock pathlib.Path.glob to return the file, but Path.exists to return False
-        original_glob = pathlib.Path.glob
-        original_exists = pathlib.Path.exists
+    assert result == []
+    captured = capsys.readouterr()
+    assert "is not a requirements.txt file (found: dependencies.txt)" in captured.err
 
-        def mock_glob(self, pattern, **kwargs):
-            return original_glob(self, pattern, **kwargs)
 
-        def mock_exists(self):
-            if self.name == "requirements.txt":
-                return False  # Simulate file was deleted
-            return original_exists(self)
+def test_gather_valid_requirements_file(fs: FakeFilesystem):
+    """Test handling of valid requirements.txt file"""
+    tmp_path = pathlib.Path("/fake/valid-file")
+    tmp_path.mkdir(parents=True)
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text("requests==2.26.0\n")
 
-        monkeypatch.setattr(pathlib.Path, "glob", mock_glob)
-        monkeypatch.setattr(pathlib.Path, "exists", mock_exists)
+    result = gather_requirements_files([req_file])
 
-        # This should handle the case gracefully
-        result = gather_requirements_files([tmp_path])
-        assert result == []
+    assert result == [req_file]
 
-    def test_symlink_handling(self, fs: FakeFilesystem):
-        """Test handling of symlinks"""
-        tmp_path = pathlib.Path("/fake/symlink-test")
-        tmp_path.mkdir(parents=True)
-        # Create a real requirements.txt file
-        real_file = tmp_path / "real_requirements.txt"
-        real_file.write_text("requests==2.26.0\n")
 
-        # Create a symlink to it named requirements.txt
-        symlink_file = tmp_path / "requirements.txt"
-        symlink_file.symlink_to(real_file)
+def test_gather_directory_with_no_requirements_files(capsys, fs: FakeFilesystem):
+    """Test handling of directory with no requirements.txt files"""
+    tmp_path = pathlib.Path("/fake/no-reqs")
+    tmp_path.mkdir(parents=True)
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
 
-        result = gather_requirements_files([symlink_file])
+    result = gather_requirements_files([empty_dir])
 
-        # Should work with symlinks
-        assert result == [symlink_file]
+    assert result == []
+    captured = capsys.readouterr()
+    assert (
+        f"Warning: No requirements.txt files found in directory '{empty_dir}'"
+        in captured.err
+    )
 
-    def test_broken_symlink_handling(self, capsys, fs: FakeFilesystem):
-        """Test handling of broken symlinks"""
-        tmp_path = pathlib.Path("/fake/broken-symlink")
-        tmp_path.mkdir(parents=True)
-        # Create a symlink to a non-existent file
-        broken_symlink = tmp_path / "requirements.txt"
-        broken_symlink.symlink_to(tmp_path / "nonexistent.txt")
 
-        result = gather_requirements_files([broken_symlink])
+def test_gather_directory_with_requirements_files(fs: FakeFilesystem):
+    """Test handling of directory with requirements.txt files"""
+    tmp_path = pathlib.Path("/fake/with-reqs")
+    tmp_path.mkdir(parents=True)
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text("requests==2.26.0\n")
 
-        # Should detect that the symlink target doesn't exist
-        assert result == []
-        # Note: Path.exists() returns False for broken symlinks
+    result = gather_requirements_files([tmp_path])
+
+    assert req_file in result
+
+
+def test_gather_mixed_valid_and_invalid_paths(capsys, fs: FakeFilesystem):
+    """Test handling mix of valid and invalid paths"""
+    tmp_path = pathlib.Path("/fake/mixed-paths")
+    tmp_path.mkdir(parents=True)
+    # Valid file
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text("requests==2.26.0\n")
+
+    # Invalid file
+    wrong_file = tmp_path / "dependencies.txt"
+    wrong_file.write_text("django==3.2.0\n")
+
+    # Non-existent path
+    nonexistent_path = tmp_path / "nonexistent"
+
+    result = gather_requirements_files([req_file, wrong_file, nonexistent_path])
+
+    assert result == [req_file]
+    captured = capsys.readouterr()
+    assert "is not a requirements.txt file" in captured.err
+    assert "does not exist" in captured.err
+
+
+def test_gather_venv_exclusion_still_works(fs: FakeFilesystem):
+    """Test that virtual environment exclusion still works"""
+    tmp_path = pathlib.Path("/fake/venv-exclusion")
+    tmp_path.mkdir(parents=True)
+    # Create a venv directory with requirements.txt
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+    venv_req = venv_dir / "requirements.txt"
+    venv_req.write_text("should-be-excluded==1.0.0\n")
+
+    # Create a normal requirements.txt
+    normal_req = tmp_path / "requirements.txt"
+    normal_req.write_text("should-be-included==1.0.0\n")
+
+    result = gather_requirements_files([tmp_path])
+
+    assert normal_req in result
+    assert venv_req not in result
+
+
+# =============================================================================
+# Command file validation tests
+# =============================================================================
+
+
+def test_find_command_nonexistent_file(
+    cli_runner: CliRunner, fs: FakeFilesystem
+) -> None:
+    """Test find command with non-existent file"""
+    result = cli_runner.invoke(find_package, ["django", "/nonexistent/path"])
+
+    assert result.exit_code == 0  # Should not crash
+    assert "Error: Path '/nonexistent/path' does not exist" in result.output
+
+
+def test_add_command_nonexistent_file(
+    cli_runner: CliRunner, fs: FakeFilesystem
+) -> None:
+    """Test add command with non-existent file"""
+    result = cli_runner.invoke(add_package, ["django", "/nonexistent/path"])
+
+    assert result.exit_code == 0  # Should not crash
+    assert "Error: Path '/nonexistent/path' does not exist" in result.output
+
+
+def test_remove_command_nonexistent_file(
+    cli_runner: CliRunner, fs: FakeFilesystem
+) -> None:
+    """Test remove command with non-existent file"""
+    result = cli_runner.invoke(remove_package, ["django", "/nonexistent/path"])
+
+    assert result.exit_code == 0  # Should not crash
+    assert "Error: Path '/nonexistent/path' does not exist" in result.output
+
+
+def test_update_command_nonexistent_file(
+    cli_runner: CliRunner, fs: FakeFilesystem
+) -> None:
+    """Test update command with non-existent file"""
+    result = cli_runner.invoke(update_package, ["django", "4.2.0", "/nonexistent/path"])
+
+    assert result.exit_code == 0  # Should not crash
+    assert "Error: Path '/nonexistent/path' does not exist" in result.output
+
+
+def test_sort_command_nonexistent_file(
+    cli_runner: CliRunner, fs: FakeFilesystem
+) -> None:
+    """Test sort command with non-existent file"""
+    result = cli_runner.invoke(sort_requirements, ["/nonexistent/path"])
+
+    assert result.exit_code == 0  # Should not crash
+    assert "Error: Path '/nonexistent/path' does not exist" in result.output
+
+
+def test_cat_command_nonexistent_file(
+    cli_runner: CliRunner, fs: FakeFilesystem
+) -> None:
+    """Test cat command with non-existent file"""
+    result = cli_runner.invoke(cat_requirements, ["/nonexistent/path"])
+
+    assert result.exit_code == 0  # Should not crash
+    assert "Error: Path '/nonexistent/path' does not exist" in result.output
+
+
+def test_wrong_filename_error_messages(
+    cli_runner: CliRunner, fs: FakeFilesystem
+) -> None:
+    """Test clear error messages for wrong filenames"""
+    tmp_path = pathlib.Path("/fake/cmd-wrong-filename")
+    tmp_path.mkdir(parents=True)
+    wrong_file = tmp_path / "dependencies.txt"
+    wrong_file.write_text("requests==2.26.0\n")
+
+    result = cli_runner.invoke(find_package, ["django", str(wrong_file)])
+
+    assert result.exit_code == 0
+    assert "is not a requirements.txt file (found: dependencies.txt)" in result.output
+
+
+def test_empty_directory_warning(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test warning for empty directories"""
+    tmp_path = pathlib.Path("/fake/cmd-empty-dir")
+    tmp_path.mkdir(parents=True)
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+
+    result = cli_runner.invoke(find_package, ["django", str(empty_dir)])
+
+    assert result.exit_code == 0
+    assert (
+        f"Warning: No requirements.txt files found in directory '{empty_dir}'"
+        in result.output
+    )
+
+
+# =============================================================================
+# Edge case tests
+# =============================================================================
+
+
+def test_file_deleted_between_glob_and_access(monkeypatch, fs: FakeFilesystem):
+    """Test handling of files deleted between directory scan and file access"""
+    tmp_path = pathlib.Path("/fake/file-deleted")
+    tmp_path.mkdir(parents=True)
+    # Create a requirements.txt file
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text("requests==2.26.0\n")
+
+    # Mock pathlib.Path.glob to return the file, but Path.exists to return False
+    original_glob = pathlib.Path.glob
+    original_exists = pathlib.Path.exists
+
+    def mock_glob(self, pattern, **kwargs):
+        return original_glob(self, pattern, **kwargs)
+
+    def mock_exists(self):
+        if self.name == "requirements.txt":
+            return False  # Simulate file was deleted
+        return original_exists(self)
+
+    monkeypatch.setattr(pathlib.Path, "glob", mock_glob)
+    monkeypatch.setattr(pathlib.Path, "exists", mock_exists)
+
+    # This should handle the case gracefully
+    result = gather_requirements_files([tmp_path])
+    assert result == []
+
+
+def test_symlink_handling(fs: FakeFilesystem):
+    """Test handling of symlinks"""
+    tmp_path = pathlib.Path("/fake/symlink-test")
+    tmp_path.mkdir(parents=True)
+    # Create a real requirements.txt file
+    real_file = tmp_path / "real_requirements.txt"
+    real_file.write_text("requests==2.26.0\n")
+
+    # Create a symlink to it named requirements.txt
+    symlink_file = tmp_path / "requirements.txt"
+    symlink_file.symlink_to(real_file)
+
+    result = gather_requirements_files([symlink_file])
+
+    # Should work with symlinks
+    assert result == [symlink_file]
+
+
+def test_broken_symlink_handling(capsys, fs: FakeFilesystem):
+    """Test handling of broken symlinks"""
+    tmp_path = pathlib.Path("/fake/broken-symlink")
+    tmp_path.mkdir(parents=True)
+    # Create a symlink to a non-existent file
+    broken_symlink = tmp_path / "requirements.txt"
+    broken_symlink.symlink_to(tmp_path / "nonexistent.txt")
+
+    result = gather_requirements_files([broken_symlink])
+
+    # Should detect that the symlink target doesn't exist
+    assert result == []
+    # Note: Path.exists() returns False for broken symlinks

--- a/tests/integration/test_find.py
+++ b/tests/integration/test_find.py
@@ -5,119 +5,116 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 
 from requirements.main import find_package
 
+# =============================================================================
+# find_package tests
+# =============================================================================
 
-class TestFindPackage:
-    """Test find_package functionality"""
 
-    def test_find_existing_package(
-        self, cli_runner: CliRunner, single_requirements_file: str
-    ) -> None:
-        """Test finding an existing package in requirements.txt"""
-        result = cli_runner.invoke(find_package, ["pytest", single_requirements_file])
-        assert result.exit_code == 0
-        assert "requirements.txt" in result.output
+def test_find_existing_package(
+    cli_runner: CliRunner, single_requirements_file: str
+) -> None:
+    """Test finding an existing package in requirements.txt"""
+    result = cli_runner.invoke(find_package, ["pytest", single_requirements_file])
+    assert result.exit_code == 0
+    assert "requirements.txt" in result.output
 
-    def test_find_nonexistent_package(
-        self, cli_runner: CliRunner, single_requirements_file: str
-    ) -> None:
-        """Test finding a non-existent package in requirements.txt"""
-        result = cli_runner.invoke(
-            find_package, ["nonexistent", single_requirements_file]
-        )
-        assert result.exit_code == 0
-        assert result.output.strip() == ""
 
-    def test_find_package_verbose(
-        self, cli_runner: CliRunner, single_requirements_file: str
-    ) -> None:
-        """Test finding a package with verbose output"""
-        result = cli_runner.invoke(
-            find_package, ["pytest", single_requirements_file, "--verbose"]
-        )
-        assert result.exit_code == 0
-        assert "requirements.txt" in result.output
-        assert "pytest" in result.output
+def test_find_nonexistent_package(
+    cli_runner: CliRunner, single_requirements_file: str
+) -> None:
+    """Test finding a non-existent package in requirements.txt"""
+    result = cli_runner.invoke(find_package, ["nonexistent", single_requirements_file])
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
 
-    def test_find_package_multiple_files(
-        self, cli_runner: CliRunner, multiple_nested_directories: str
-    ) -> None:
-        """Test finding a package in multiple requirements files"""
-        result = cli_runner.invoke(
-            find_package, ["pytest", multiple_nested_directories]
-        )
-        assert result.exit_code == 0
-        assert result.output.count("requirements.txt") == 4
 
-    def test_find_package_with_git_url(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test finding a package specified as a git URL with egg fragment."""
-        tmp_path = pathlib.Path("/fake/find-git-url")
-        tmp_path.mkdir(parents=True)
-        req_file = tmp_path / "requirements.txt"
-        req_file.write_text("git+https://github.com/user/mypackage.git#egg=mypackage\n")
+def test_find_package_verbose(
+    cli_runner: CliRunner, single_requirements_file: str
+) -> None:
+    """Test finding a package with verbose output"""
+    result = cli_runner.invoke(
+        find_package, ["pytest", single_requirements_file, "--verbose"]
+    )
+    assert result.exit_code == 0
+    assert "requirements.txt" in result.output
+    assert "pytest" in result.output
 
-        result = cli_runner.invoke(find_package, ["mypackage", str(tmp_path)])
 
-        assert result.exit_code == 0
-        assert "requirements.txt" in result.output
+def test_find_package_multiple_files(
+    cli_runner: CliRunner, multiple_nested_directories: str
+) -> None:
+    """Test finding a package in multiple requirements files"""
+    result = cli_runner.invoke(find_package, ["pytest", multiple_nested_directories])
+    assert result.exit_code == 0
+    assert result.output.count("requirements.txt") == 4
 
-    def test_find_package_with_pep440_url(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test finding a package specified with PEP 440 URL syntax."""
-        tmp_path = pathlib.Path("/fake/find-pep440")
-        tmp_path.mkdir(parents=True)
-        req_file = tmp_path / "requirements.txt"
-        req_file.write_text("mypackage @ https://example.com/mypackage-1.0.whl\n")
 
-        result = cli_runner.invoke(find_package, ["mypackage", str(tmp_path)])
+def test_find_package_with_git_url(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test finding a package specified as a git URL with egg fragment."""
+    tmp_path = pathlib.Path("/fake/find-git-url")
+    tmp_path.mkdir(parents=True)
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text("git+https://github.com/user/mypackage.git#egg=mypackage\n")
 
-        assert result.exit_code == 0
-        assert "requirements.txt" in result.output
+    result = cli_runner.invoke(find_package, ["mypackage", str(tmp_path)])
 
-    def test_find_package_with_github_repo_fallback(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test finding a package by GitHub repo name when no egg fragment."""
-        tmp_path = pathlib.Path("/fake/find-github")
-        tmp_path.mkdir(parents=True)
-        req_file = tmp_path / "requirements.txt"
-        req_file.write_text("git+https://github.com/user/my-repo.git\n")
+    assert result.exit_code == 0
+    assert "requirements.txt" in result.output
 
-        result = cli_runner.invoke(find_package, ["my-repo", str(tmp_path)])
 
-        assert result.exit_code == 0
-        assert "requirements.txt" in result.output
+def test_find_package_with_pep440_url(
+    cli_runner: CliRunner, fs: FakeFilesystem
+) -> None:
+    """Test finding a package specified with PEP 440 URL syntax."""
+    tmp_path = pathlib.Path("/fake/find-pep440")
+    tmp_path.mkdir(parents=True)
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text("mypackage @ https://example.com/mypackage-1.0.whl\n")
 
-    def test_find_package_url_verbose(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test finding a URL package with verbose output."""
-        tmp_path = pathlib.Path("/fake/find-verbose")
-        tmp_path.mkdir(parents=True)
-        url_line = "git+https://github.com/user/repo.git@v1.0#egg=mypackage"
-        req_file = tmp_path / "requirements.txt"
-        req_file.write_text(f"{url_line}\n")
+    result = cli_runner.invoke(find_package, ["mypackage", str(tmp_path)])
 
-        result = cli_runner.invoke(
-            find_package, ["mypackage", str(tmp_path), "--verbose"]
-        )
+    assert result.exit_code == 0
+    assert "requirements.txt" in result.output
 
-        assert result.exit_code == 0
-        assert "requirements.txt" in result.output
-        assert url_line in result.output
 
-    def test_find_package_url_not_found(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test that non-matching URL packages are not found."""
-        tmp_path = pathlib.Path("/fake/find-not-found")
-        tmp_path.mkdir(parents=True)
-        req_file = tmp_path / "requirements.txt"
-        req_file.write_text("git+https://github.com/user/other.git#egg=other\n")
+def test_find_package_with_github_repo_fallback(
+    cli_runner: CliRunner, fs: FakeFilesystem
+) -> None:
+    """Test finding a package by GitHub repo name when no egg fragment."""
+    tmp_path = pathlib.Path("/fake/find-github")
+    tmp_path.mkdir(parents=True)
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text("git+https://github.com/user/my-repo.git\n")
 
-        result = cli_runner.invoke(find_package, ["mypackage", str(tmp_path)])
+    result = cli_runner.invoke(find_package, ["my-repo", str(tmp_path)])
 
-        assert result.exit_code == 0
-        assert result.output.strip() == ""
+    assert result.exit_code == 0
+    assert "requirements.txt" in result.output
+
+
+def test_find_package_url_verbose(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test finding a URL package with verbose output."""
+    tmp_path = pathlib.Path("/fake/find-verbose")
+    tmp_path.mkdir(parents=True)
+    url_line = "git+https://github.com/user/repo.git@v1.0#egg=mypackage"
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text(f"{url_line}\n")
+
+    result = cli_runner.invoke(find_package, ["mypackage", str(tmp_path), "--verbose"])
+
+    assert result.exit_code == 0
+    assert "requirements.txt" in result.output
+    assert url_line in result.output
+
+
+def test_find_package_url_not_found(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test that non-matching URL packages are not found."""
+    tmp_path = pathlib.Path("/fake/find-not-found")
+    tmp_path.mkdir(parents=True)
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text("git+https://github.com/user/other.git#egg=other\n")
+
+    result = cli_runner.invoke(find_package, ["mypackage", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == ""

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -12,319 +12,331 @@ from requirements.main import (
     update_package,
 )
 
-
-class TestCLIIntegration:
-    """Test full CLI integration"""
-
-    def test_cli_help(self, cli_runner: CliRunner) -> None:
-        """Test CLI help output"""
-        result = cli_runner.invoke(cli, ["--help"])
-        assert result.exit_code == 0
-        assert "Manage requirements.txt files" in result.output
-
-    def test_cli_version(self, cli_runner: CliRunner) -> None:
-        """Test CLI version output"""
-        result = cli_runner.invoke(cli, ["--version"])
-        # Version command may fail if package not installed, but should handle gracefully
-        assert result.exit_code in [0, 1]
-
-    def test_update_command_help(self, cli_runner: CliRunner) -> None:
-        """Test update command help"""
-        result = cli_runner.invoke(cli, ["update", "--help"])
-        assert result.exit_code == 0
-        assert "Update a package version" in result.output
-
-    def test_add_command_help(self, cli_runner: CliRunner) -> None:
-        """Test add command help"""
-        result = cli_runner.invoke(cli, ["add", "--help"])
-        assert result.exit_code == 0
-        assert "Add a package" in result.output
-
-    def test_remove_command_help(self, cli_runner: CliRunner) -> None:
-        """Test remove command help"""
-        result = cli_runner.invoke(cli, ["remove", "--help"])
-        assert result.exit_code == 0
-        assert "Remove a package" in result.output
-
-    def test_find_command_help(self, cli_runner: CliRunner) -> None:
-        """Test find command help"""
-        result = cli_runner.invoke(cli, ["find", "--help"])
-        assert result.exit_code == 0
-        assert "Find a package" in result.output
-
-    def test_sort_command_help(self, cli_runner: CliRunner) -> None:
-        """Test sort command help"""
-        result = cli_runner.invoke(cli, ["sort", "--help"])
-        assert result.exit_code == 0
-        assert "Sort requirements.txt" in result.output
-
-    def test_cat_command_help(self, cli_runner: CliRunner) -> None:
-        """Test cat command help"""
-        result = cli_runner.invoke(cli, ["cat", "--help"])
-        assert result.exit_code == 0
-        assert "Display the contents" in result.output
+# =============================================================================
+# CLI integration tests
+# =============================================================================
 
 
-class TestComplexScenarios:
-    """Test complex real-world scenarios"""
-
-    def test_workflow_add_update_remove(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test complete workflow: add, update, then remove a package"""
-        td = pathlib.Path("/fake/workflow-test")
-        td.mkdir(parents=True)
-        requirements_file = td / "requirements.txt"
-        requirements_file.write_text("requests==2.25.1\n")
-
-        # Add a package
-        result = cli_runner.invoke(add_package, ["pytest", str(td)])
-        assert result.exit_code == 0
-        contents = requirements_file.read_text()
-        assert "pytest" in contents
-        assert "requests==2.25.1" in contents
-
-        # Update the package
-        result = cli_runner.invoke(update_package, ["pytest", ">=6.0.0", str(td)])
-        assert result.exit_code == 0
-        contents = requirements_file.read_text()
-        assert "pytest>=6.0.0" in contents
-
-        # Remove the package
-        result = cli_runner.invoke(remove_package, ["pytest", str(td)])
-        assert result.exit_code == 0
-        contents = requirements_file.read_text()
-        assert "pytest" not in contents
-        assert "requests==2.25.1" in contents
-
-    def test_mixed_package_formats(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test handling mixed package formats"""
-        td = pathlib.Path("/fake/mixed-formats")
-        td.mkdir(parents=True)
-        requirements_file = td / "requirements.txt"
-        requirements_file.write_text(
-            "requests==2.25.1\n"
-            "boto3~=1.0.0\n"
-            "pytest>=6.0.0\n"
-            "django<4.0.0\n"
-            "# comment line\n"
-            "./local_package\n"
-            "git+https://github.com/user/repo.git\n"
-        )
-
-        # Test finding packages with different formats
-        result = cli_runner.invoke(find_package, ["requests", str(td)])
-        assert result.exit_code == 0
-        assert "requirements.txt" in result.output
-
-        result = cli_runner.invoke(find_package, ["local_package", str(td)])
-        assert result.exit_code == 0
-        assert "requirements.txt" in result.output
-
-    def test_large_monorepo_simulation(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test performance with many nested directories"""
-        td = pathlib.Path("/fake/monorepo")
-        td.mkdir(parents=True)
-
-        # Create 10 nested directories with requirements files
-        for i in range(10):
-            dir_path = td / f"service_{i}"
-            dir_path.mkdir()
-            req_file = dir_path / "requirements.txt"
-            req_file.write_text(f"service_{i}_dependency==1.0.0\ncommon_lib==2.0.0\n")
-
-        # Test finding common package across all files
-        result = cli_runner.invoke(find_package, ["common_lib", str(td)])
-        assert result.exit_code == 0
-        assert result.output.count("requirements.txt") == 10
-
-        # Test updating common package across all files
-        result = cli_runner.invoke(update_package, ["common_lib", "3.0.0", str(td)])
-        assert result.exit_code == 0
-
-        # Verify all files were updated
-        for i in range(10):
-            req_file = td / f"service_{i}" / "requirements.txt"
-            contents = req_file.read_text()
-            assert "common_lib==3.0.0" in contents
+def test_cli_help(cli_runner: CliRunner) -> None:
+    """Test CLI help output"""
+    result = cli_runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "Manage requirements.txt files" in result.output
 
 
-class TestErrorHandling:
-    """Test error handling scenarios"""
-
-    def test_invalid_path(self, cli_runner: CliRunner, fs: FakeFilesystem) -> None:
-        """Test handling invalid file paths"""
-        result = cli_runner.invoke(find_package, ["pytest", "/nonexistent/path"])
-        assert result.exit_code == 0
-        assert "does not exist" in result.output
-
-    def test_empty_requirements_file(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test handling empty requirements files"""
-        td = pathlib.Path("/fake/empty")
-        td.mkdir(parents=True)
-        requirements_file = td / "requirements.txt"
-        requirements_file.write_text("")
-
-        result = cli_runner.invoke(find_package, ["pytest", str(td)])
-        assert result.exit_code == 0
-        assert result.output.strip() == ""
-
-    def test_malformed_requirements_file(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test handling malformed requirements files"""
-        td = pathlib.Path("/fake/malformed")
-        td.mkdir(parents=True)
-        requirements_file = td / "requirements.txt"
-        requirements_file.write_text("# Just a comment\n\n# Another comment\n")
-
-        result = cli_runner.invoke(find_package, ["pytest", str(td)])
-        assert result.exit_code == 0
-        assert result.output.strip() == ""
+def test_cli_version(cli_runner: CliRunner) -> None:
+    """Test CLI version output"""
+    result = cli_runner.invoke(cli, ["--version"])
+    # Version command may fail if package not installed, but should handle gracefully
+    assert result.exit_code in [0, 1]
 
 
-class TestVirtualEnvironmentExclusion:
-    """Test virtual environment directory exclusion"""
-
-    def test_exclude_venv_directory(
-        self, cli_runner: CliRunner, requirements_txt: bytes, fs: FakeFilesystem
-    ) -> None:
-        """Test that venv directories are excluded"""
-        td = pathlib.Path("/fake/venv-test")
-        td.mkdir(parents=True)
-        # Create main requirements file
-        main_req = td / "requirements.txt"
-        main_req.write_text(requirements_txt.decode("utf-8"))
-
-        # Create venv directory with requirements file
-        venv_dir = td / "venv"
-        venv_dir.mkdir()
-        venv_req = venv_dir / "requirements.txt"
-        venv_req.write_text("should_be_excluded\n")
-
-        # Test that venv requirements are excluded
-        result = cli_runner.invoke(find_package, ["should_be_excluded", str(td)])
-        assert result.exit_code == 0
-        assert result.output.strip() == ""
-
-    def test_exclude_dot_venv_directory(
-        self, cli_runner: CliRunner, requirements_txt: bytes, fs: FakeFilesystem
-    ) -> None:
-        """Test that .venv directories are excluded"""
-        td = pathlib.Path("/fake/dotvenv-test")
-        td.mkdir(parents=True)
-        # Create main requirements file
-        main_req = td / "requirements.txt"
-        main_req.write_text(requirements_txt.decode("utf-8"))
-
-        # Create .venv directory with requirements file
-        venv_dir = td / ".venv"
-        venv_dir.mkdir()
-        venv_req = venv_dir / "requirements.txt"
-        venv_req.write_text("should_be_excluded\n")
-
-        # Test that .venv requirements are excluded
-        result = cli_runner.invoke(find_package, ["should_be_excluded", str(td)])
-        assert result.exit_code == 0
-        assert result.output.strip() == ""
-
-    def test_exclude_virtualenv_directory(
-        self, cli_runner: CliRunner, requirements_txt: bytes, fs: FakeFilesystem
-    ) -> None:
-        """Test that virtualenv directories are excluded"""
-        td = pathlib.Path("/fake/virtualenv-test")
-        td.mkdir(parents=True)
-        # Create main requirements file
-        main_req = td / "requirements.txt"
-        main_req.write_text(requirements_txt.decode("utf-8"))
-
-        # Create virtualenv directory with requirements file
-        venv_dir = td / "virtualenv"
-        venv_dir.mkdir()
-        venv_req = venv_dir / "requirements.txt"
-        venv_req.write_text("should_be_excluded\n")
-
-        # Test that virtualenv requirements are excluded
-        result = cli_runner.invoke(find_package, ["should_be_excluded", str(td)])
-        assert result.exit_code == 0
-        assert result.output.strip() == ""
+def test_update_command_help(cli_runner: CliRunner) -> None:
+    """Test update command help"""
+    result = cli_runner.invoke(cli, ["update", "--help"])
+    assert result.exit_code == 0
+    assert "Update a package version" in result.output
 
 
-class TestSortSummary:
-    """Test sort command summary output for multiple files."""
-
-    def test_sort_multiple_files_summary(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test that sorting multiple files shows a summary."""
-        tmp_path = pathlib.Path("/fake/sort-multiple")
-        tmp_path.mkdir(parents=True)
-        # Create 3 unsorted requirements files
-        for name in ["project1", "project2", "project3"]:
-            subdir = tmp_path / name
-            subdir.mkdir()
-            req_file = subdir / "requirements.txt"
-            req_file.write_text("zebra==1.0.0\napple==2.0.0\nbanana==3.0.0\n")
-
-        result = cli_runner.invoke(cli, ["sort", str(tmp_path)])
-
-        assert result.exit_code == 0
-        assert "Summary:" in result.output
-        assert "3 sorted" in result.output
-        assert "3 files total" in result.output
-
-    def test_sort_mixed_files_summary(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test summary with mix of sorted and unsorted files."""
-        tmp_path = pathlib.Path("/fake/sort-mixed")
-        tmp_path.mkdir(parents=True)
-        # Create one already sorted file
-        sorted_dir = tmp_path / "sorted"
-        sorted_dir.mkdir()
-        (sorted_dir / "requirements.txt").write_text("apple==1.0.0\nzebra==2.0.0\n")
-
-        # Create one unsorted file
-        unsorted_dir = tmp_path / "unsorted"
-        unsorted_dir.mkdir()
-        (unsorted_dir / "requirements.txt").write_text("zebra==2.0.0\napple==1.0.0\n")
-
-        result = cli_runner.invoke(cli, ["sort", str(tmp_path)])
-
-        assert result.exit_code == 0
-        assert "Summary:" in result.output
-        assert "1 sorted" in result.output
-        assert "1 already sorted" in result.output
-        assert "2 files total" in result.output
+def test_add_command_help(cli_runner: CliRunner) -> None:
+    """Test add command help"""
+    result = cli_runner.invoke(cli, ["add", "--help"])
+    assert result.exit_code == 0
+    assert "Add a package" in result.output
 
 
-class TestCLIEntryPoint:
-    """Test that the CLI entry point is installed and functional"""
+def test_remove_command_help(cli_runner: CliRunner) -> None:
+    """Test remove command help"""
+    result = cli_runner.invoke(cli, ["remove", "--help"])
+    assert result.exit_code == 0
+    assert "Remove a package" in result.output
 
-    def test_cli_entry_point_help(self) -> None:
-        """Verify the CLI entry point responds to --help"""
-        result = subprocess.run(
-            ["requirements", "--help"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        assert result.returncode == 0
-        assert "Manage requirements.txt files" in result.stdout
 
-    def test_cli_entry_point_version(self) -> None:
-        """Verify the CLI entry point responds to --version"""
-        result = subprocess.run(
-            ["requirements", "--version"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        assert result.returncode == 0
-        assert "requirements" in result.stdout.lower()
+def test_find_command_help(cli_runner: CliRunner) -> None:
+    """Test find command help"""
+    result = cli_runner.invoke(cli, ["find", "--help"])
+    assert result.exit_code == 0
+    assert "Find a package" in result.output
+
+
+def test_sort_command_help(cli_runner: CliRunner) -> None:
+    """Test sort command help"""
+    result = cli_runner.invoke(cli, ["sort", "--help"])
+    assert result.exit_code == 0
+    assert "Sort requirements.txt" in result.output
+
+
+def test_cat_command_help(cli_runner: CliRunner) -> None:
+    """Test cat command help"""
+    result = cli_runner.invoke(cli, ["cat", "--help"])
+    assert result.exit_code == 0
+    assert "Display the contents" in result.output
+
+
+# =============================================================================
+# Complex real-world scenario tests
+# =============================================================================
+
+
+def test_workflow_add_update_remove(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test complete workflow: add, update, then remove a package"""
+    td = pathlib.Path("/fake/workflow-test")
+    td.mkdir(parents=True)
+    requirements_file = td / "requirements.txt"
+    requirements_file.write_text("requests==2.25.1\n")
+
+    # Add a package
+    result = cli_runner.invoke(add_package, ["pytest", str(td)])
+    assert result.exit_code == 0
+    contents = requirements_file.read_text()
+    assert "pytest" in contents
+    assert "requests==2.25.1" in contents
+
+    # Update the package
+    result = cli_runner.invoke(update_package, ["pytest", ">=6.0.0", str(td)])
+    assert result.exit_code == 0
+    contents = requirements_file.read_text()
+    assert "pytest>=6.0.0" in contents
+
+    # Remove the package
+    result = cli_runner.invoke(remove_package, ["pytest", str(td)])
+    assert result.exit_code == 0
+    contents = requirements_file.read_text()
+    assert "pytest" not in contents
+    assert "requests==2.25.1" in contents
+
+
+def test_mixed_package_formats(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test handling mixed package formats"""
+    td = pathlib.Path("/fake/mixed-formats")
+    td.mkdir(parents=True)
+    requirements_file = td / "requirements.txt"
+    requirements_file.write_text(
+        "requests==2.25.1\n"
+        "boto3~=1.0.0\n"
+        "pytest>=6.0.0\n"
+        "django<4.0.0\n"
+        "# comment line\n"
+        "./local_package\n"
+        "git+https://github.com/user/repo.git\n"
+    )
+
+    # Test finding packages with different formats
+    result = cli_runner.invoke(find_package, ["requests", str(td)])
+    assert result.exit_code == 0
+    assert "requirements.txt" in result.output
+
+    result = cli_runner.invoke(find_package, ["local_package", str(td)])
+    assert result.exit_code == 0
+    assert "requirements.txt" in result.output
+
+
+def test_large_monorepo_simulation(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test performance with many nested directories"""
+    td = pathlib.Path("/fake/monorepo")
+    td.mkdir(parents=True)
+
+    # Create 10 nested directories with requirements files
+    for i in range(10):
+        dir_path = td / f"service_{i}"
+        dir_path.mkdir()
+        req_file = dir_path / "requirements.txt"
+        req_file.write_text(f"service_{i}_dependency==1.0.0\ncommon_lib==2.0.0\n")
+
+    # Test finding common package across all files
+    result = cli_runner.invoke(find_package, ["common_lib", str(td)])
+    assert result.exit_code == 0
+    assert result.output.count("requirements.txt") == 10
+
+    # Test updating common package across all files
+    result = cli_runner.invoke(update_package, ["common_lib", "3.0.0", str(td)])
+    assert result.exit_code == 0
+
+    # Verify all files were updated
+    for i in range(10):
+        req_file = td / f"service_{i}" / "requirements.txt"
+        contents = req_file.read_text()
+        assert "common_lib==3.0.0" in contents
+
+
+# =============================================================================
+# Error handling tests
+# =============================================================================
+
+
+def test_invalid_path(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test handling invalid file paths"""
+    result = cli_runner.invoke(find_package, ["pytest", "/nonexistent/path"])
+    assert result.exit_code == 0
+    assert "does not exist" in result.output
+
+
+def test_empty_requirements_file(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test handling empty requirements files"""
+    td = pathlib.Path("/fake/empty")
+    td.mkdir(parents=True)
+    requirements_file = td / "requirements.txt"
+    requirements_file.write_text("")
+
+    result = cli_runner.invoke(find_package, ["pytest", str(td)])
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+def test_malformed_requirements_file(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test handling malformed requirements files"""
+    td = pathlib.Path("/fake/malformed")
+    td.mkdir(parents=True)
+    requirements_file = td / "requirements.txt"
+    requirements_file.write_text("# Just a comment\n\n# Another comment\n")
+
+    result = cli_runner.invoke(find_package, ["pytest", str(td)])
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+# =============================================================================
+# Virtual environment exclusion tests
+# =============================================================================
+
+
+def test_exclude_venv_directory(
+    cli_runner: CliRunner, requirements_txt: bytes, fs: FakeFilesystem
+) -> None:
+    """Test that venv directories are excluded"""
+    td = pathlib.Path("/fake/venv-test")
+    td.mkdir(parents=True)
+    # Create main requirements file
+    main_req = td / "requirements.txt"
+    main_req.write_text(requirements_txt.decode("utf-8"))
+
+    # Create venv directory with requirements file
+    venv_dir = td / "venv"
+    venv_dir.mkdir()
+    venv_req = venv_dir / "requirements.txt"
+    venv_req.write_text("should_be_excluded\n")
+
+    # Test that venv requirements are excluded
+    result = cli_runner.invoke(find_package, ["should_be_excluded", str(td)])
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+def test_exclude_dot_venv_directory(
+    cli_runner: CliRunner, requirements_txt: bytes, fs: FakeFilesystem
+) -> None:
+    """Test that .venv directories are excluded"""
+    td = pathlib.Path("/fake/dotvenv-test")
+    td.mkdir(parents=True)
+    # Create main requirements file
+    main_req = td / "requirements.txt"
+    main_req.write_text(requirements_txt.decode("utf-8"))
+
+    # Create .venv directory with requirements file
+    venv_dir = td / ".venv"
+    venv_dir.mkdir()
+    venv_req = venv_dir / "requirements.txt"
+    venv_req.write_text("should_be_excluded\n")
+
+    # Test that .venv requirements are excluded
+    result = cli_runner.invoke(find_package, ["should_be_excluded", str(td)])
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+def test_exclude_virtualenv_directory(
+    cli_runner: CliRunner, requirements_txt: bytes, fs: FakeFilesystem
+) -> None:
+    """Test that virtualenv directories are excluded"""
+    td = pathlib.Path("/fake/virtualenv-test")
+    td.mkdir(parents=True)
+    # Create main requirements file
+    main_req = td / "requirements.txt"
+    main_req.write_text(requirements_txt.decode("utf-8"))
+
+    # Create virtualenv directory with requirements file
+    venv_dir = td / "virtualenv"
+    venv_dir.mkdir()
+    venv_req = venv_dir / "requirements.txt"
+    venv_req.write_text("should_be_excluded\n")
+
+    # Test that virtualenv requirements are excluded
+    result = cli_runner.invoke(find_package, ["should_be_excluded", str(td)])
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+# =============================================================================
+# Sort summary tests
+# =============================================================================
+
+
+def test_sort_multiple_files_summary(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test that sorting multiple files shows a summary."""
+    tmp_path = pathlib.Path("/fake/sort-multiple")
+    tmp_path.mkdir(parents=True)
+    # Create 3 unsorted requirements files
+    for name in ["project1", "project2", "project3"]:
+        subdir = tmp_path / name
+        subdir.mkdir()
+        req_file = subdir / "requirements.txt"
+        req_file.write_text("zebra==1.0.0\napple==2.0.0\nbanana==3.0.0\n")
+
+    result = cli_runner.invoke(cli, ["sort", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "Summary:" in result.output
+    assert "3 sorted" in result.output
+    assert "3 files total" in result.output
+
+
+def test_sort_mixed_files_summary(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test summary with mix of sorted and unsorted files."""
+    tmp_path = pathlib.Path("/fake/sort-mixed")
+    tmp_path.mkdir(parents=True)
+    # Create one already sorted file
+    sorted_dir = tmp_path / "sorted"
+    sorted_dir.mkdir()
+    (sorted_dir / "requirements.txt").write_text("apple==1.0.0\nzebra==2.0.0\n")
+
+    # Create one unsorted file
+    unsorted_dir = tmp_path / "unsorted"
+    unsorted_dir.mkdir()
+    (unsorted_dir / "requirements.txt").write_text("zebra==2.0.0\napple==1.0.0\n")
+
+    result = cli_runner.invoke(cli, ["sort", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "Summary:" in result.output
+    assert "1 sorted" in result.output
+    assert "1 already sorted" in result.output
+    assert "2 files total" in result.output
+
+
+# =============================================================================
+# CLI entry point tests
+# =============================================================================
+
+
+def test_cli_entry_point_help() -> None:
+    """Verify the CLI entry point responds to --help"""
+    result = subprocess.run(
+        ["requirements", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Manage requirements.txt files" in result.stdout
+
+
+def test_cli_entry_point_version() -> None:
+    """Verify the CLI entry point responds to --version"""
+    result = subprocess.run(
+        ["requirements", "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "requirements" in result.stdout.lower()

--- a/tests/integration/test_remove.py
+++ b/tests/integration/test_remove.py
@@ -5,77 +5,78 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 
 from requirements.main import remove_package
 
+# =============================================================================
+# remove_package tests
+# =============================================================================
 
-class TestRemovePackage:
-    """Test remove_package functionality"""
 
-    def test_remove_existing_package(
-        self, cli_runner: CliRunner, single_requirements_file: str
-    ) -> None:
-        """Test removing an existing package from requirements.txt"""
-        result = cli_runner.invoke(remove_package, ["pytest", single_requirements_file])
-        assert result.exit_code == 0
-        assert "Removed pytest" in result.output
+def test_remove_existing_package(
+    cli_runner: CliRunner, single_requirements_file: str
+) -> None:
+    """Test removing an existing package from requirements.txt"""
+    result = cli_runner.invoke(remove_package, ["pytest", single_requirements_file])
+    assert result.exit_code == 0
+    assert "Removed pytest" in result.output
+    contents = (pathlib.Path(single_requirements_file) / "requirements.txt").read_text()
+    assert "pytest" not in contents
+    assert "boto3~=1.0.0" in contents
+    assert "enhancement-models==1.0.0" in contents
+
+
+def test_remove_nonexistent_package(
+    cli_runner: CliRunner, single_requirements_file: str
+) -> None:
+    """Test removing a non-existent package from requirements.txt"""
+    result = cli_runner.invoke(
+        remove_package, ["nonexistent", single_requirements_file]
+    )
+    assert result.exit_code == 0
+    contents = (pathlib.Path(single_requirements_file) / "requirements.txt").read_text()
+    assert contents == "pytest\nboto3~=1.0.0\nenhancement-models==1.0.0\n"
+
+
+def test_remove_package_with_preview(
+    cli_runner: CliRunner, single_requirements_file: str
+) -> None:
+    """Test removing a package with preview flag"""
+    # Store original contents before preview
+    original_contents = (
+        pathlib.Path(single_requirements_file) / "requirements.txt"
+    ).read_text()
+
+    result = cli_runner.invoke(
+        remove_package, ["pytest", single_requirements_file, "--preview"]
+    )
+    assert result.exit_code == 0
+    assert "Previewing changes" in result.output
+    # After preview, pytest should be shown as removed in diff-style
+    assert "-pytest" in result.output
+
+    # File should remain unchanged in preview mode
+    contents = (pathlib.Path(single_requirements_file) / "requirements.txt").read_text()
+    assert contents == original_contents
+    assert "pytest" in contents  # pytest should still be in the file
+
+
+def test_remove_package_multiple_files(
+    cli_runner: CliRunner, multiple_nested_directories: str
+) -> None:
+    """Test removing a package from multiple requirements files"""
+    result = cli_runner.invoke(remove_package, ["pytest", multiple_nested_directories])
+    assert result.exit_code == 0
+
+    for i in range(3):
         contents = (
-            pathlib.Path(single_requirements_file) / "requirements.txt"
+            pathlib.Path(multiple_nested_directories)
+            / f"directory{i}"
+            / "requirements.txt"
         ).read_text()
         assert "pytest" not in contents
-        assert "boto3~=1.0.0" in contents
-        assert "enhancement-models==1.0.0" in contents
 
-    def test_remove_nonexistent_package(
-        self, cli_runner: CliRunner, single_requirements_file: str
-    ) -> None:
-        """Test removing a non-existent package from requirements.txt"""
-        result = cli_runner.invoke(
-            remove_package, ["nonexistent", single_requirements_file]
-        )
-        assert result.exit_code == 0
-        contents = (
-            pathlib.Path(single_requirements_file) / "requirements.txt"
-        ).read_text()
-        assert contents == "pytest\nboto3~=1.0.0\nenhancement-models==1.0.0\n"
 
-    def test_remove_package_with_preview(
-        self, cli_runner: CliRunner, single_requirements_file: str
-    ) -> None:
-        """Test removing a package with preview flag"""
-        # Store original contents before preview
-        original_contents = (
-            pathlib.Path(single_requirements_file) / "requirements.txt"
-        ).read_text()
-
-        result = cli_runner.invoke(
-            remove_package, ["pytest", single_requirements_file, "--preview"]
-        )
-        assert result.exit_code == 0
-        assert "Previewing changes" in result.output
-        # After preview, pytest should be shown as removed in diff-style
-        assert "-pytest" in result.output
-
-        # File should remain unchanged in preview mode
-        contents = (
-            pathlib.Path(single_requirements_file) / "requirements.txt"
-        ).read_text()
-        assert contents == original_contents
-        assert "pytest" in contents  # pytest should still be in the file
-
-    def test_remove_package_multiple_files(
-        self, cli_runner: CliRunner, multiple_nested_directories: str
-    ) -> None:
-        """Test removing a package from multiple requirements files"""
-        result = cli_runner.invoke(
-            remove_package, ["pytest", multiple_nested_directories]
-        )
-        assert result.exit_code == 0
-
-        for i in range(3):
-            contents = (
-                pathlib.Path(multiple_nested_directories)
-                / f"directory{i}"
-                / "requirements.txt"
-            ).read_text()
-            assert "pytest" not in contents
+# =============================================================================
+# Inline comments tests
+# =============================================================================
 
 
 def test_remove_package_preserves_inline_comments(

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -6,47 +6,54 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 
 from requirements.main import update_package
 
+# =============================================================================
+# Preview changes tests
+# =============================================================================
 
-class TestPreviewChanges:
-    """Test previewing changes against files"""
 
-    def test_single_requirements_file(
-        self, cli_runner: CliRunner, single_requirements_file: str
-    ) -> None:
-        result = cli_runner.invoke(
-            update_package,
-            [
-                "pytest",
-                "~=6.0.0",
-                single_requirements_file,
-                "--preview",
-            ],
-        )
-        assert result.exit_code == 0
-        assert "Previewing changes" in result.output
-        assert f"{single_requirements_file}/requirements.txt" in result.output
-        assert "-pytest" in result.output
-        assert "+pytest~=6.0.0" in result.output
+def test_preview_single_requirements_file(
+    cli_runner: CliRunner, single_requirements_file: str
+) -> None:
+    """Test previewing changes on a single requirements file"""
+    result = cli_runner.invoke(
+        update_package,
+        [
+            "pytest",
+            "~=6.0.0",
+            single_requirements_file,
+            "--preview",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Previewing changes" in result.output
+    assert f"{single_requirements_file}/requirements.txt" in result.output
+    assert "-pytest" in result.output
+    assert "+pytest~=6.0.0" in result.output
 
-        # assert that file contents are unchanged
-        contents = (
-            pathlib.Path(single_requirements_file) / "requirements.txt"
-        ).read_text()
-        assert contents == "pytest\nboto3~=1.0.0\nenhancement-models==1.0.0\n"
+    # assert that file contents are unchanged
+    contents = (pathlib.Path(single_requirements_file) / "requirements.txt").read_text()
+    assert contents == "pytest\nboto3~=1.0.0\nenhancement-models==1.0.0\n"
 
-    def test_multiple_requirements_files(
-        self, cli_runner: CliRunner, multiple_nested_directories: str
-    ) -> None:
-        result = cli_runner.invoke(
-            update_package,
-            [
-                "pytest",
-                "~=6.0.0",
-                multiple_nested_directories,
-                "--preview",
-            ],
-        )
-        assert result.exit_code == 0
+
+def test_preview_multiple_requirements_files(
+    cli_runner: CliRunner, multiple_nested_directories: str
+) -> None:
+    """Test previewing changes on multiple requirements files"""
+    result = cli_runner.invoke(
+        update_package,
+        [
+            "pytest",
+            "~=6.0.0",
+            multiple_nested_directories,
+            "--preview",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+# =============================================================================
+# Update package tests
+# =============================================================================
 
 
 def test_single_requirements_file_in_directory(

--- a/tests/integration/test_versions.py
+++ b/tests/integration/test_versions.py
@@ -9,364 +9,366 @@ from click.testing import CliRunner
 
 from requirements.main import cli
 
-
-class TestVersionsCommand:
-    """Test the versions CLI command."""
-
-    def test_versions_command_help(self, cli_runner: CliRunner) -> None:
-        """Test that --help works for versions command."""
-        result = cli_runner.invoke(cli, ["versions", "--help"])
-        assert result.exit_code == 0
-        assert "Show available versions" in result.output
-        assert "--all" in result.output
-        assert "--limit" in result.output
-        assert "--index-url" in result.output
-
-    def test_versions_command_success(
-        self, cli_runner: CliRunner, requests_simple_html: str
-    ) -> None:
-        """Test successful versions query with mocked HTTP response."""
-        mock_response = MagicMock()
-        mock_response.read.return_value = requests_simple_html.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch("urllib.request.urlopen", return_value=mock_response):
-            result = cli_runner.invoke(cli, ["versions", "requests"])
-
-        assert result.exit_code == 0
-        assert "requests" in result.output
-        assert "2.32.3" in result.output  # Latest version
-        assert "latest" in result.output
-
-    def test_versions_command_all_flag(
-        self, cli_runner: CliRunner, requests_simple_html: str
-    ) -> None:
-        """Test versions command with --all flag."""
-        mock_response = MagicMock()
-        mock_response.read.return_value = requests_simple_html.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch("urllib.request.urlopen", return_value=mock_response):
-            result = cli_runner.invoke(cli, ["versions", "requests", "--all"])
-
-        assert result.exit_code == 0
-        assert "requests" in result.output
-        # All 4 non-yanked versions should be shown
-        assert "2.32.3" in result.output
-        assert "2.31.0" in result.output
-        assert "2.28.1" in result.output
-        assert "2.28.0" in result.output
-        # No "showing X of Y" hint
-        assert "use --all" not in result.output
-
-    def test_versions_command_limit_flag(
-        self, cli_runner: CliRunner, requests_simple_html: str
-    ) -> None:
-        """Test versions command with --limit flag."""
-        mock_response = MagicMock()
-        mock_response.read.return_value = requests_simple_html.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch("urllib.request.urlopen", return_value=mock_response):
-            result = cli_runner.invoke(cli, ["versions", "requests", "--limit", "2"])
-
-        assert result.exit_code == 0
-        assert "2.32.3" in result.output
-        assert "showing 2 of 4 versions" in result.output
-
-    def test_versions_command_index_url(
-        self, cli_runner: CliRunner, requests_simple_html: str
-    ) -> None:
-        """Test versions command with --index-url flag."""
-        mock_response = MagicMock()
-        mock_response.read.return_value = requests_simple_html.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch(
-            "urllib.request.urlopen", return_value=mock_response
-        ) as mock_urlopen:
-            result = cli_runner.invoke(
-                cli,
-                [
-                    "versions",
-                    "requests",
-                    "--index-url",
-                    "https://nexus.example.com/simple",
-                ],
-            )
-
-        assert result.exit_code == 0
-        # Verify the custom index URL was used
-        call_args = mock_urlopen.call_args
-        request = call_args[0][0]
-        assert "nexus.example.com" in request.full_url
-
-    def test_versions_command_package_not_found(self, cli_runner: CliRunner) -> None:
-        """Test versions command when package is not found."""
-        error = urllib.error.HTTPError(
-            url="https://pypi.org/simple/nonexistent/",
-            code=404,
-            msg="Not Found",
-            hdrs={},  # type: ignore[arg-type]
-            fp=None,
-        )
-
-        with patch("urllib.request.urlopen", side_effect=error):
-            result = cli_runner.invoke(cli, ["versions", "nonexistent-package-xyz"])
-
-        assert result.exit_code == 1
-        assert "not found" in result.output.lower()
-
-    def test_versions_command_network_error(self, cli_runner: CliRunner) -> None:
-        """Test versions command with network error."""
-        error = urllib.error.URLError("Connection refused")
-
-        with patch("urllib.request.urlopen", side_effect=error):
-            result = cli_runner.invoke(cli, ["versions", "requests"])
-
-        assert result.exit_code == 1
-        assert "Failed to fetch" in result.output
-        assert "Connection refused" in result.output
-
-    def test_versions_fewer_than_limit(
-        self, cli_runner: CliRunner, requests_simple_html: str
-    ) -> None:
-        """Test versions command when there are fewer versions than limit."""
-        mock_response = MagicMock()
-        mock_response.read.return_value = requests_simple_html.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch("urllib.request.urlopen", return_value=mock_response):
-            result = cli_runner.invoke(cli, ["versions", "requests"])
-
-        assert result.exit_code == 0
-        # We have 4 versions, default limit is 10, so no "use --all" hint
-        assert "use --all" not in result.output
-
-    def test_versions_excludes_yanked(
-        self, cli_runner: CliRunner, requests_simple_html: str
-    ) -> None:
-        """Test that yanked versions are excluded by default."""
-        mock_response = MagicMock()
-        mock_response.read.return_value = requests_simple_html.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch("urllib.request.urlopen", return_value=mock_response):
-            result = cli_runner.invoke(cli, ["versions", "requests", "--all"])
-
-        assert result.exit_code == 0
-        # 2.32.0 is yanked and should not appear
-        assert "2.32.0" not in result.output
-        # Other versions should appear
-        assert "2.32.3" in result.output
-        assert "2.31.0" in result.output
-
-    def test_versions_command_http_error(self, cli_runner: CliRunner) -> None:
-        """Test versions command with HTTP error (not 404)."""
-        error = urllib.error.HTTPError(
-            url="https://pypi.org/simple/requests/",
-            code=500,
-            msg="Internal Server Error",
-            hdrs={},  # type: ignore[arg-type]
-            fp=None,
-        )
-
-        with patch("urllib.request.urlopen", side_effect=error):
-            result = cli_runner.invoke(cli, ["versions", "requests"])
-
-        assert result.exit_code == 1
-        assert "Failed to fetch" in result.output
-        assert "500" in result.output or "Internal Server Error" in result.output
-
-    def test_versions_no_versions_found(self, cli_runner: CliRunner) -> None:
-        """Test versions command when no versions are found."""
-        empty_html = """
-        <!DOCTYPE html>
-        <html><body><h1>Links for empty-package</h1></body></html>
-        """
-        mock_response = MagicMock()
-        mock_response.read.return_value = empty_html.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch("urllib.request.urlopen", return_value=mock_response):
-            result = cli_runner.invoke(cli, ["versions", "empty-package"])
-
-        assert result.exit_code == 1
-        assert "No versions found" in result.output
-
-    def test_versions_one_per_line_flag(
-        self,
-        cli_runner: CliRunner,
-        requests_simple_html: str,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Test versions command with -1/--one-per-line flag."""
-        mock_response = MagicMock()
-        mock_response.read.return_value = requests_simple_html.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        monkeypatch.setattr(
-            "urllib.request.urlopen", lambda *args, **kwargs: mock_response
-        )
-
-        result = cli_runner.invoke(cli, ["versions", "requests", "-1"])
-
-        assert result.exit_code == 0
-        # Each version should be on its own line
-        lines = result.output.strip().split("\n")
-        # First line is the package header, then versions
-        assert "2.32.3" in lines[1]
-        assert "2.31.0" in lines[2]
-        # Should not have comma-separated output
-        assert "Available versions:" not in result.output
-
-    def test_versions_one_per_line_long_flag(
-        self,
-        cli_runner: CliRunner,
-        requests_simple_html: str,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Test versions command with --one-per-line long flag."""
-        mock_response = MagicMock()
-        mock_response.read.return_value = requests_simple_html.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        monkeypatch.setattr(
-            "urllib.request.urlopen", lambda *args, **kwargs: mock_response
-        )
-
-        result = cli_runner.invoke(cli, ["versions", "requests", "--one-per-line"])
-
-        assert result.exit_code == 0
-        # Should not have comma-separated output
-        assert "Available versions:" not in result.output
-        # Versions should be on separate lines
-        assert "2.32.3\n" in result.output
+# =============================================================================
+# versions CLI command tests
+# =============================================================================
 
 
-class TestVersionsWithConfig:
-    """Test versions command with configuration integration."""
+def test_versions_command_help(cli_runner: CliRunner) -> None:
+    """Test that --help works for versions command."""
+    result = cli_runner.invoke(cli, ["versions", "--help"])
+    assert result.exit_code == 0
+    assert "Show available versions" in result.output
+    assert "--all" in result.output
+    assert "--limit" in result.output
+    assert "--index-url" in result.output
 
-    def test_versions_uses_config_index_url(
-        self,
-        cli_runner: CliRunner,
-        requests_simple_html: str,
-        fake_home: pathlib.Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Test that versions command uses configured index URL."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
 
-        # Set config
-        cli_runner.invoke(
-            cli,
-            ["config", "set", "pypi.index_url", "https://config.example.com/simple/"],
-        )
+def test_versions_command_success(
+    cli_runner: CliRunner, requests_simple_html: str
+) -> None:
+    """Test successful versions query with mocked HTTP response."""
+    mock_response = MagicMock()
+    mock_response.read.return_value = requests_simple_html.encode("utf-8")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
 
-        mock_response = MagicMock()
-        mock_response.read.return_value = requests_simple_html.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        result = cli_runner.invoke(cli, ["versions", "requests"])
 
-        with patch(
-            "urllib.request.urlopen", return_value=mock_response
-        ) as mock_urlopen:
-            result = cli_runner.invoke(cli, ["versions", "requests"])
+    assert result.exit_code == 0
+    assert "requests" in result.output
+    assert "2.32.3" in result.output  # Latest version
+    assert "latest" in result.output
 
-        assert result.exit_code == 0
-        # Verify config URL was used
-        call_args = mock_urlopen.call_args
-        request = call_args[0][0]
-        assert "config.example.com" in request.full_url
 
-    def test_versions_cli_flag_overrides_config(
-        self,
-        cli_runner: CliRunner,
-        requests_simple_html: str,
-        fake_home: pathlib.Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Test that --index-url flag overrides config."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+def test_versions_command_all_flag(
+    cli_runner: CliRunner, requests_simple_html: str
+) -> None:
+    """Test versions command with --all flag."""
+    mock_response = MagicMock()
+    mock_response.read.return_value = requests_simple_html.encode("utf-8")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
 
-        # Set config to one URL
-        cli_runner.invoke(
-            cli,
-            ["config", "set", "pypi.index_url", "https://config.example.com/simple/"],
-        )
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        result = cli_runner.invoke(cli, ["versions", "requests", "--all"])
 
-        mock_response = MagicMock()
-        mock_response.read.return_value = requests_simple_html.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
+    assert result.exit_code == 0
+    assert "requests" in result.output
+    # All 4 non-yanked versions should be shown
+    assert "2.32.3" in result.output
+    assert "2.31.0" in result.output
+    assert "2.28.1" in result.output
+    assert "2.28.0" in result.output
+    # No "showing X of Y" hint
+    assert "use --all" not in result.output
 
-        with patch(
-            "urllib.request.urlopen", return_value=mock_response
-        ) as mock_urlopen:
-            result = cli_runner.invoke(
-                cli,
-                [
-                    "versions",
-                    "requests",
-                    "--index-url",
-                    "https://cli-override.example.com/simple/",
-                ],
-            )
 
-        assert result.exit_code == 0
-        # Verify CLI flag URL was used, not config
-        call_args = mock_urlopen.call_args
-        request = call_args[0][0]
-        assert "cli-override.example.com" in request.full_url
-        assert "config.example.com" not in request.full_url
+def test_versions_command_limit_flag(
+    cli_runner: CliRunner, requests_simple_html: str
+) -> None:
+    """Test versions command with --limit flag."""
+    mock_response = MagicMock()
+    mock_response.read.return_value = requests_simple_html.encode("utf-8")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
 
-    def test_versions_uses_fallback_on_primary_failure(
-        self,
-        cli_runner: CliRunner,
-        requests_simple_html: str,
-        fake_home: pathlib.Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Test that versions command uses fallback URL on primary failure."""
-        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        result = cli_runner.invoke(cli, ["versions", "requests", "--limit", "2"])
 
-        # Set both primary and fallback URLs
-        cli_runner.invoke(
-            cli,
-            ["config", "set", "pypi.index_url", "https://primary.example.com/simple/"],
-        )
-        cli_runner.invoke(
+    assert result.exit_code == 0
+    assert "2.32.3" in result.output
+    assert "showing 2 of 4 versions" in result.output
+
+
+def test_versions_command_index_url(
+    cli_runner: CliRunner, requests_simple_html: str
+) -> None:
+    """Test versions command with --index-url flag."""
+    mock_response = MagicMock()
+    mock_response.read.return_value = requests_simple_html.encode("utf-8")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+        result = cli_runner.invoke(
             cli,
             [
-                "config",
-                "set",
-                "pypi.fallback_url",
-                "https://fallback.example.com/simple/",
+                "versions",
+                "requests",
+                "--index-url",
+                "https://nexus.example.com/simple",
             ],
         )
 
-        mock_response = MagicMock()
-        mock_response.read.return_value = requests_simple_html.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
+    assert result.exit_code == 0
+    # Verify the custom index URL was used
+    call_args = mock_urlopen.call_args
+    request = call_args[0][0]
+    assert "nexus.example.com" in request.full_url
 
-        def side_effect(request, **kwargs):
-            if "primary" in request.full_url:
-                raise urllib.error.URLError("Connection refused")
-            return mock_response
 
-        with patch("urllib.request.urlopen", side_effect=side_effect):
-            result = cli_runner.invoke(cli, ["versions", "requests"])
+def test_versions_command_package_not_found(cli_runner: CliRunner) -> None:
+    """Test versions command when package is not found."""
+    error = urllib.error.HTTPError(
+        url="https://pypi.org/simple/nonexistent/",
+        code=404,
+        msg="Not Found",
+        hdrs={},  # type: ignore[arg-type]
+        fp=None,
+    )
 
-        assert result.exit_code == 0
-        assert "requests" in result.output
-        assert "2.32.3" in result.output  # Latest version from fixture
+    with patch("urllib.request.urlopen", side_effect=error):
+        result = cli_runner.invoke(cli, ["versions", "nonexistent-package-xyz"])
+
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()
+
+
+def test_versions_command_network_error(cli_runner: CliRunner) -> None:
+    """Test versions command with network error."""
+    error = urllib.error.URLError("Connection refused")
+
+    with patch("urllib.request.urlopen", side_effect=error):
+        result = cli_runner.invoke(cli, ["versions", "requests"])
+
+    assert result.exit_code == 1
+    assert "Failed to fetch" in result.output
+    assert "Connection refused" in result.output
+
+
+def test_versions_fewer_than_limit(
+    cli_runner: CliRunner, requests_simple_html: str
+) -> None:
+    """Test versions command when there are fewer versions than limit."""
+    mock_response = MagicMock()
+    mock_response.read.return_value = requests_simple_html.encode("utf-8")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        result = cli_runner.invoke(cli, ["versions", "requests"])
+
+    assert result.exit_code == 0
+    # We have 4 versions, default limit is 10, so no "use --all" hint
+    assert "use --all" not in result.output
+
+
+def test_versions_excludes_yanked(
+    cli_runner: CliRunner, requests_simple_html: str
+) -> None:
+    """Test that yanked versions are excluded by default."""
+    mock_response = MagicMock()
+    mock_response.read.return_value = requests_simple_html.encode("utf-8")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        result = cli_runner.invoke(cli, ["versions", "requests", "--all"])
+
+    assert result.exit_code == 0
+    # 2.32.0 is yanked and should not appear
+    assert "2.32.0" not in result.output
+    # Other versions should appear
+    assert "2.32.3" in result.output
+    assert "2.31.0" in result.output
+
+
+def test_versions_command_http_error(cli_runner: CliRunner) -> None:
+    """Test versions command with HTTP error (not 404)."""
+    error = urllib.error.HTTPError(
+        url="https://pypi.org/simple/requests/",
+        code=500,
+        msg="Internal Server Error",
+        hdrs={},  # type: ignore[arg-type]
+        fp=None,
+    )
+
+    with patch("urllib.request.urlopen", side_effect=error):
+        result = cli_runner.invoke(cli, ["versions", "requests"])
+
+    assert result.exit_code == 1
+    assert "Failed to fetch" in result.output
+    assert "500" in result.output or "Internal Server Error" in result.output
+
+
+def test_versions_no_versions_found(cli_runner: CliRunner) -> None:
+    """Test versions command when no versions are found."""
+    empty_html = """
+    <!DOCTYPE html>
+    <html><body><h1>Links for empty-package</h1></body></html>
+    """
+    mock_response = MagicMock()
+    mock_response.read.return_value = empty_html.encode("utf-8")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        result = cli_runner.invoke(cli, ["versions", "empty-package"])
+
+    assert result.exit_code == 1
+    assert "No versions found" in result.output
+
+
+def test_versions_one_per_line_flag(
+    cli_runner: CliRunner,
+    requests_simple_html: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test versions command with -1/--one-per-line flag."""
+    mock_response = MagicMock()
+    mock_response.read.return_value = requests_simple_html.encode("utf-8")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *args, **kwargs: mock_response)
+
+    result = cli_runner.invoke(cli, ["versions", "requests", "-1"])
+
+    assert result.exit_code == 0
+    # Each version should be on its own line
+    lines = result.output.strip().split("\n")
+    # First line is the package header, then versions
+    assert "2.32.3" in lines[1]
+    assert "2.31.0" in lines[2]
+    # Should not have comma-separated output
+    assert "Available versions:" not in result.output
+
+
+def test_versions_one_per_line_long_flag(
+    cli_runner: CliRunner,
+    requests_simple_html: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test versions command with --one-per-line long flag."""
+    mock_response = MagicMock()
+    mock_response.read.return_value = requests_simple_html.encode("utf-8")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *args, **kwargs: mock_response)
+
+    result = cli_runner.invoke(cli, ["versions", "requests", "--one-per-line"])
+
+    assert result.exit_code == 0
+    # Should not have comma-separated output
+    assert "Available versions:" not in result.output
+    # Versions should be on separate lines
+    assert "2.32.3\n" in result.output
+
+
+# =============================================================================
+# versions command with configuration integration tests
+# =============================================================================
+
+
+def test_versions_uses_config_index_url(
+    cli_runner: CliRunner,
+    requests_simple_html: str,
+    fake_home: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that versions command uses configured index URL."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    # Set config
+    cli_runner.invoke(
+        cli,
+        ["config", "set", "pypi.index_url", "https://config.example.com/simple/"],
+    )
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = requests_simple_html.encode("utf-8")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+        result = cli_runner.invoke(cli, ["versions", "requests"])
+
+    assert result.exit_code == 0
+    # Verify config URL was used
+    call_args = mock_urlopen.call_args
+    request = call_args[0][0]
+    assert "config.example.com" in request.full_url
+
+
+def test_versions_cli_flag_overrides_config(
+    cli_runner: CliRunner,
+    requests_simple_html: str,
+    fake_home: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that --index-url flag overrides config."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    # Set config to one URL
+    cli_runner.invoke(
+        cli,
+        ["config", "set", "pypi.index_url", "https://config.example.com/simple/"],
+    )
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = requests_simple_html.encode("utf-8")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+        result = cli_runner.invoke(
+            cli,
+            [
+                "versions",
+                "requests",
+                "--index-url",
+                "https://cli-override.example.com/simple/",
+            ],
+        )
+
+    assert result.exit_code == 0
+    # Verify CLI flag URL was used, not config
+    call_args = mock_urlopen.call_args
+    request = call_args[0][0]
+    assert "cli-override.example.com" in request.full_url
+    assert "config.example.com" not in request.full_url
+
+
+def test_versions_uses_fallback_on_primary_failure(
+    cli_runner: CliRunner,
+    requests_simple_html: str,
+    fake_home: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that versions command uses fallback URL on primary failure."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    # Set both primary and fallback URLs
+    cli_runner.invoke(
+        cli,
+        ["config", "set", "pypi.index_url", "https://primary.example.com/simple/"],
+    )
+    cli_runner.invoke(
+        cli,
+        [
+            "config",
+            "set",
+            "pypi.fallback_url",
+            "https://fallback.example.com/simple/",
+        ],
+    )
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = requests_simple_html.encode("utf-8")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    def side_effect(request, **kwargs):
+        if "primary" in request.full_url:
+            raise urllib.error.URLError("Connection refused")
+        return mock_response
+
+    with patch("urllib.request.urlopen", side_effect=side_effect):
+        result = cli_runner.invoke(cli, ["versions", "requests"])
+
+    assert result.exit_code == 0
+    assert "requests" in result.output
+    assert "2.32.3" in result.output  # Latest version from fixture

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,8 +1,9 @@
 """Tests for config module."""
 
-from pathlib import Path
+import pathlib
 
 import pytest
+from pyfakefs.fake_filesystem import FakeFilesystem
 
 from requirements.config import (
     _format_toml_value,
@@ -10,8 +11,13 @@ from requirements.config import (
     get_config_dir,
     get_config_file,
     get_default_config_content,
+    get_pypi_fallback_url,
+    get_pypi_index_url,
+    get_setting,
     load_config,
     save_color_setting,
+    save_setting,
+    unset_setting,
 )
 
 
@@ -19,7 +25,7 @@ def test_get_config_dir():
     """Test that config dir is in home directory."""
     config_dir = get_config_dir()
     assert config_dir.name == ".requirements"
-    assert config_dir.parent == Path.home()
+    assert config_dir.parent == pathlib.Path.home()
 
 
 def test_get_config_file():
@@ -29,27 +35,33 @@ def test_get_config_file():
     assert config_file.parent == get_config_dir()
 
 
-def test_load_config_returns_empty_when_no_file(tmp_path, monkeypatch):
+def test_load_config_returns_empty_when_no_file(
+    fs: FakeFilesystem, fake_home: pathlib.Path, monkeypatch
+):
     """Test that load_config returns empty dict when no config file."""
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
     config = load_config()
     assert config == {}
 
 
-def test_get_color_setting_returns_none_when_not_configured(tmp_path, monkeypatch):
+def test_get_color_setting_returns_none_when_not_configured(
+    fs: FakeFilesystem, fake_home: pathlib.Path, monkeypatch
+):
     """Test that get_color_setting returns None when not configured."""
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
     result = get_color_setting()
     assert result is None
 
 
-def test_save_and_load_color_setting(tmp_path, monkeypatch):
+def test_save_and_load_color_setting(
+    fs: FakeFilesystem, fake_home: pathlib.Path, monkeypatch
+):
     """Test saving and loading color setting."""
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
 
     save_color_setting(True)
 
-    config_file = tmp_path / ".requirements" / "config.toml"
+    config_file = fake_home / ".requirements" / "config.toml"
     assert config_file.exists()
 
     config = load_config()
@@ -96,3 +108,115 @@ def test_format_toml_value_escapes_special_characters(input_value, expected):
 def test_format_toml_value_types(input_value, expected):
     """Test TOML formatting for various types."""
     assert _format_toml_value(input_value) == expected
+
+
+def test_get_setting_returns_none_when_not_configured(
+    fs: FakeFilesystem, fake_home: pathlib.Path, monkeypatch
+):
+    """Test that get_setting returns None when not configured."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+    result = get_setting("pypi", "index_url")
+    assert result is None
+
+
+def test_save_and_get_setting(fs: FakeFilesystem, fake_home: pathlib.Path, monkeypatch):
+    """Test saving and loading settings with generic functions."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    save_setting("pypi", "index_url", "https://example.com/simple/")
+    result = get_setting("pypi", "index_url")
+    assert result == "https://example.com/simple/"
+
+
+@pytest.mark.parametrize(
+    ("section", "key", "value"),
+    [
+        ("color", "enabled", True),
+        ("color", "enabled", False),
+        ("pypi", "index_url", "https://nexus.example.com/simple/"),
+        ("pypi", "fallback_url", "https://pypi.org/simple/"),
+    ],
+)
+def test_save_setting_various_types(
+    fs: FakeFilesystem, fake_home: pathlib.Path, monkeypatch, section, key, value
+):
+    """Test saving various setting types."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+    save_setting(section, key, value)
+    assert get_setting(section, key) == value
+
+
+def test_unset_setting_removes_key(
+    fs: FakeFilesystem, fake_home: pathlib.Path, monkeypatch
+):
+    """Test that unset_setting removes a key."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    save_setting("pypi", "index_url", "https://example.com/simple/")
+    assert get_setting("pypi", "index_url") is not None
+
+    result = unset_setting("pypi", "index_url")
+    assert result is True
+    assert get_setting("pypi", "index_url") is None
+
+
+def test_unset_setting_removes_empty_section(
+    fs: FakeFilesystem, fake_home: pathlib.Path, monkeypatch
+):
+    """Test that unset_setting removes empty sections."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    save_setting("pypi", "index_url", "https://example.com/simple/")
+    unset_setting("pypi", "index_url")
+
+    config = load_config()
+    assert "pypi" not in config
+
+
+def test_unset_setting_returns_false_if_not_exists(
+    fs: FakeFilesystem, fake_home: pathlib.Path, monkeypatch
+):
+    """Test that unset_setting returns False if setting doesn't exist."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+    result = unset_setting("nonexistent", "setting")
+    assert result is False
+
+
+def test_get_pypi_index_url(fs: FakeFilesystem, fake_home: pathlib.Path, monkeypatch):
+    """Test get_pypi_index_url returns configured URL."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    assert get_pypi_index_url() is None
+
+    save_setting("pypi", "index_url", "https://nexus.example.com/simple/")
+    assert get_pypi_index_url() == "https://nexus.example.com/simple/"
+
+
+def test_get_pypi_fallback_url(
+    fs: FakeFilesystem, fake_home: pathlib.Path, monkeypatch
+):
+    """Test get_pypi_fallback_url returns configured URL."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    assert get_pypi_fallback_url() is None
+
+    save_setting("pypi", "fallback_url", "https://pypi.org/simple/")
+    assert get_pypi_fallback_url() == "https://pypi.org/simple/"
+
+
+def test_get_pypi_url_returns_none_for_non_string(
+    fs: FakeFilesystem, fake_home: pathlib.Path, monkeypatch
+):
+    """Test that PyPI URL getters return None for non-string values."""
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    save_setting("pypi", "index_url", 123)
+    assert get_pypi_index_url() is None
+
+
+def test_default_config_includes_pypi_section():
+    """Test that default config content includes pypi section."""
+    content = get_default_config_content()
+    assert "[pypi]" in content
+    assert "index_url" in content
+    assert "fallback_url" in content

--- a/tests/unit/test_pypi.py
+++ b/tests/unit/test_pypi.py
@@ -13,255 +13,286 @@ from requirements.pypi import (
     fetch_with_fallback,
 )
 
-
-class TestSimpleAPIParser:
-    """Tests for the HTML parser."""
-
-    def test_parse_wheel_files(self) -> None:
-        html = """
-        <a href="url">requests-2.28.0-py3-none-any.whl</a>
-        <a href="url">requests-2.28.1-py3-none-any.whl</a>
-        """
-        parser = SimpleAPIParser()
-        parser.feed(html)
-        assert len(parser.files) == 2
-        assert parser.files[0] == ("requests-2.28.0-py3-none-any.whl", False)
-        assert parser.files[1] == ("requests-2.28.1-py3-none-any.whl", False)
-
-    def test_parse_sdist_files(self) -> None:
-        html = """
-        <a href="url">requests-2.28.0.tar.gz</a>
-        <a href="url">requests-2.28.1.tar.gz</a>
-        """
-        parser = SimpleAPIParser()
-        parser.feed(html)
-        assert len(parser.files) == 2
-        assert parser.files[0] == ("requests-2.28.0.tar.gz", False)
-        assert parser.files[1] == ("requests-2.28.1.tar.gz", False)
-
-    def test_parse_yanked_files(self) -> None:
-        html = """
-        <a href="url">requests-2.28.0-py3-none-any.whl</a>
-        <a href="url" data-yanked="security issue">requests-2.28.1-py3-none-any.whl</a>
-        """
-        parser = SimpleAPIParser()
-        parser.feed(html)
-        assert len(parser.files) == 2
-        assert parser.files[0] == ("requests-2.28.0-py3-none-any.whl", False)
-        assert parser.files[1] == ("requests-2.28.1-py3-none-any.whl", True)
-
-    def test_parse_full_fixture(self, requests_simple_html: str) -> None:
-        parser = SimpleAPIParser()
-        parser.feed(requests_simple_html)
-        # Should have 10 files (5 versions x 2 formats each)
-        assert len(parser.files) == 10
-        # Check yanked versions are marked
-        yanked_files = [f for f, is_yanked in parser.files if is_yanked]
-        assert len(yanked_files) == 2  # 2.32.0 wheel and sdist
+# =============================================================================
+# SimpleAPIParser tests
+# =============================================================================
 
 
-class TestExtractVersionFromFilename:
-    """Tests for version extraction from filenames."""
-
-    @pytest.mark.parametrize(
-        "filename,package,expected",
-        [
-            ("requests-2.28.0-py3-none-any.whl", "requests", "2.28.0"),
-            ("requests-2.28.0.tar.gz", "requests", "2.28.0"),
-            ("Django-4.2.0-py3-none-any.whl", "django", "4.2.0"),
-            ("Django-4.2.0.tar.gz", "Django", "4.2.0"),
-            ("my_package-1.0.0-py3-none-any.whl", "my-package", "1.0.0"),
-            ("my-package-1.0.0.tar.gz", "my_package", "1.0.0"),
-            ("boto3-1.26.100-py3-none-any.whl", "boto3", "1.26.100"),
-            ("numpy-1.24.0-cp311-cp311-macosx_10_9_x86_64.whl", "numpy", "1.24.0"),
-        ],
-    )
-    def test_extract_version(self, filename: str, package: str, expected: str) -> None:
-        result = _extract_version_from_filename(filename, package)
-        assert result == expected
-
-    def test_extract_version_no_match(self) -> None:
-        result = _extract_version_from_filename("other-1.0.0.tar.gz", "requests")
-        assert result is None
+def test_parser_parse_wheel_files() -> None:
+    """Test parsing wheel file links."""
+    html = """
+    <a href="url">requests-2.28.0-py3-none-any.whl</a>
+    <a href="url">requests-2.28.1-py3-none-any.whl</a>
+    """
+    parser = SimpleAPIParser()
+    parser.feed(html)
+    assert len(parser.files) == 2
+    assert parser.files[0] == ("requests-2.28.0-py3-none-any.whl", False)
+    assert parser.files[1] == ("requests-2.28.1-py3-none-any.whl", False)
 
 
-class TestFetchPackageVersions:
-    """Tests for fetching package versions."""
-
-    def test_fetch_versions_from_fixture(self, mock_pypi_response: MagicMock) -> None:
-        with patch("urllib.request.urlopen", return_value=mock_pypi_response):
-            versions = fetch_package_versions("requests")
-
-        # Should have 4 versions (2.32.0 is yanked and excluded)
-        assert len(versions) == 4
-        # Should be sorted newest first
-        assert versions[0] == "2.32.3"
-        assert versions[1] == "2.31.0"
-        assert versions[2] == "2.28.1"
-        assert versions[3] == "2.28.0"
-
-    def test_fetch_versions_include_yanked(self, mock_pypi_response: MagicMock) -> None:
-        with patch("urllib.request.urlopen", return_value=mock_pypi_response):
-            versions = fetch_package_versions("requests", include_yanked=True)
-
-        # Should have 5 versions (including yanked 2.32.0)
-        assert len(versions) == 5
-        assert "2.32.0" in versions
-
-    def test_fetch_versions_custom_index(self, mock_pypi_response: MagicMock) -> None:
-        with patch(
-            "urllib.request.urlopen", return_value=mock_pypi_response
-        ) as mock_urlopen:
-            fetch_package_versions(
-                "requests", index_url="https://nexus.example.com/simple"
-            )
-
-        # Verify the custom index URL was used
-        call_args = mock_urlopen.call_args
-        request = call_args[0][0]
-        assert "nexus.example.com" in request.full_url
-
-    def test_fetch_versions_normalizes_package_name(
-        self, mock_pypi_response: MagicMock
-    ) -> None:
-        with patch(
-            "urllib.request.urlopen", return_value=mock_pypi_response
-        ) as mock_urlopen:
-            fetch_package_versions("My_Package.Name")
-
-        # Verify the package name was normalized (PEP 503)
-        call_args = mock_urlopen.call_args
-        request = call_args[0][0]
-        assert "my-package-name" in request.full_url
+def test_parser_parse_sdist_files() -> None:
+    """Test parsing sdist file links."""
+    html = """
+    <a href="url">requests-2.28.0.tar.gz</a>
+    <a href="url">requests-2.28.1.tar.gz</a>
+    """
+    parser = SimpleAPIParser()
+    parser.feed(html)
+    assert len(parser.files) == 2
+    assert parser.files[0] == ("requests-2.28.0.tar.gz", False)
+    assert parser.files[1] == ("requests-2.28.1.tar.gz", False)
 
 
-class TestPyPIFetchError:
-    """Tests for PyPIFetchError exception."""
+def test_parser_parse_yanked_files() -> None:
+    """Test parsing yanked file links."""
+    html = """
+    <a href="url">requests-2.28.0-py3-none-any.whl</a>
+    <a href="url" data-yanked="security issue">requests-2.28.1-py3-none-any.whl</a>
+    """
+    parser = SimpleAPIParser()
+    parser.feed(html)
+    assert len(parser.files) == 2
+    assert parser.files[0] == ("requests-2.28.0-py3-none-any.whl", False)
+    assert parser.files[1] == ("requests-2.28.1-py3-none-any.whl", True)
 
-    def test_error_attributes(self) -> None:
-        original = ValueError("original error")
-        error = PyPIFetchError("https://example.com", original)
 
-        assert error.url == "https://example.com"
-        assert error.original_error is original
-        assert "https://example.com" in str(error)
-        assert "original error" in str(error)
+def test_parser_parse_full_fixture(requests_simple_html: str) -> None:
+    """Test parsing full PyPI Simple API HTML fixture."""
+    parser = SimpleAPIParser()
+    parser.feed(requests_simple_html)
+    # Should have 10 files (5 versions x 2 formats each)
+    assert len(parser.files) == 10
+    # Check yanked versions are marked
+    yanked_files = [f for f, is_yanked in parser.files if is_yanked]
+    assert len(yanked_files) == 2  # 2.32.0 wheel and sdist
 
 
-class TestFetchWithFallback:
-    """Tests for fetch_with_fallback function."""
+# =============================================================================
+# Version extraction tests
+# =============================================================================
 
-    def test_returns_primary_on_success(self, mock_pypi_response: MagicMock) -> None:
-        """Test that primary URL results are returned on success."""
-        with patch("urllib.request.urlopen", return_value=mock_pypi_response):
-            versions, url_used = fetch_with_fallback(
-                "requests",
-                index_url="https://primary.example.com/simple/",
-                fallback_url="https://fallback.example.com/simple/",
-            )
 
-        assert len(versions) == 4
-        assert url_used == "https://primary.example.com/simple/"
+@pytest.mark.parametrize(
+    ("filename", "package", "expected"),
+    [
+        ("requests-2.28.0-py3-none-any.whl", "requests", "2.28.0"),
+        ("requests-2.28.0.tar.gz", "requests", "2.28.0"),
+        ("Django-4.2.0-py3-none-any.whl", "django", "4.2.0"),
+        ("Django-4.2.0.tar.gz", "Django", "4.2.0"),
+        ("my_package-1.0.0-py3-none-any.whl", "my-package", "1.0.0"),
+        ("my-package-1.0.0.tar.gz", "my_package", "1.0.0"),
+        ("boto3-1.26.100-py3-none-any.whl", "boto3", "1.26.100"),
+        ("numpy-1.24.0-cp311-cp311-macosx_10_9_x86_64.whl", "numpy", "1.24.0"),
+    ],
+)
+def test_extract_version_from_filename(
+    filename: str, package: str, expected: str
+) -> None:
+    """Test extracting version from various filename formats."""
+    result = _extract_version_from_filename(filename, package)
+    assert result == expected
 
-    def test_uses_fallback_on_network_error(
-        self, mock_pypi_response: MagicMock
-    ) -> None:
-        """Test that fallback is used on network error."""
 
-        def side_effect(request, **kwargs):
-            if "primary" in request.full_url:
-                raise urllib.error.URLError("Connection refused")
-            return mock_pypi_response
+def test_extract_version_from_filename_no_match() -> None:
+    """Test that non-matching filename returns None."""
+    result = _extract_version_from_filename("other-1.0.0.tar.gz", "requests")
+    assert result is None
 
-        with patch("urllib.request.urlopen", side_effect=side_effect):
-            versions, url_used = fetch_with_fallback(
-                "requests",
-                index_url="https://primary.example.com/simple/",
-                fallback_url="https://fallback.example.com/simple/",
-            )
 
-        assert len(versions) == 4
-        assert url_used == "https://fallback.example.com/simple/"
+# =============================================================================
+# fetch_package_versions tests
+# =============================================================================
 
-    def test_uses_fallback_on_server_error(self, mock_pypi_response: MagicMock) -> None:
-        """Test that fallback is used on HTTP 500 error."""
 
-        def side_effect(request, **kwargs):
-            if "primary" in request.full_url:
-                raise urllib.error.HTTPError(
-                    url=request.full_url,
-                    code=500,
-                    msg="Internal Server Error",
-                    hdrs={},  # type: ignore[arg-type]
-                    fp=None,
-                )
-            return mock_pypi_response
+def test_fetch_versions_from_fixture(mock_pypi_response: MagicMock) -> None:
+    """Test fetching versions from PyPI fixture."""
+    with patch("urllib.request.urlopen", return_value=mock_pypi_response):
+        versions = fetch_package_versions("requests")
 
-        with patch("urllib.request.urlopen", side_effect=side_effect):
-            versions, url_used = fetch_with_fallback(
-                "requests",
-                index_url="https://primary.example.com/simple/",
-                fallback_url="https://fallback.example.com/simple/",
-            )
+    # Should have 4 versions (2.32.0 is yanked and excluded)
+    assert len(versions) == 4
+    # Should be sorted newest first
+    assert versions[0] == "2.32.3"
+    assert versions[1] == "2.31.0"
+    assert versions[2] == "2.28.1"
+    assert versions[3] == "2.28.0"
 
-        assert len(versions) == 4
-        assert url_used == "https://fallback.example.com/simple/"
 
-    def test_no_fallback_on_404(self) -> None:
-        """Test that 404 does NOT trigger fallback."""
-        error = urllib.error.HTTPError(
-            url="https://primary.example.com/simple/nonexistent/",
-            code=404,
-            msg="Not Found",
-            hdrs={},  # type: ignore[arg-type]
-            fp=None,
+def test_fetch_versions_include_yanked(mock_pypi_response: MagicMock) -> None:
+    """Test fetching versions including yanked packages."""
+    with patch("urllib.request.urlopen", return_value=mock_pypi_response):
+        versions = fetch_package_versions("requests", include_yanked=True)
+
+    # Should have 5 versions (including yanked 2.32.0)
+    assert len(versions) == 5
+    assert "2.32.0" in versions
+
+
+def test_fetch_versions_custom_index(mock_pypi_response: MagicMock) -> None:
+    """Test fetching versions from custom index URL."""
+    with patch(
+        "urllib.request.urlopen", return_value=mock_pypi_response
+    ) as mock_urlopen:
+        fetch_package_versions("requests", index_url="https://nexus.example.com/simple")
+
+    # Verify the custom index URL was used
+    call_args = mock_urlopen.call_args
+    request = call_args[0][0]
+    assert "nexus.example.com" in request.full_url
+
+
+def test_fetch_versions_normalizes_package_name(mock_pypi_response: MagicMock) -> None:
+    """Test that package names are normalized per PEP 503."""
+    with patch(
+        "urllib.request.urlopen", return_value=mock_pypi_response
+    ) as mock_urlopen:
+        fetch_package_versions("My_Package.Name")
+
+    # Verify the package name was normalized (PEP 503)
+    call_args = mock_urlopen.call_args
+    request = call_args[0][0]
+    assert "my-package-name" in request.full_url
+
+
+# =============================================================================
+# PyPIFetchError tests
+# =============================================================================
+
+
+def test_pypi_fetch_error_attributes() -> None:
+    """Test PyPIFetchError stores URL and original error."""
+    original = ValueError("original error")
+    error = PyPIFetchError("https://example.com", original)
+
+    assert error.url == "https://example.com"
+    assert error.original_error is original
+    assert "https://example.com" in str(error)
+    assert "original error" in str(error)
+
+
+# =============================================================================
+# fetch_with_fallback tests
+# =============================================================================
+
+
+def test_fallback_returns_primary_on_success(mock_pypi_response: MagicMock) -> None:
+    """Test that primary URL results are returned on success."""
+    with patch("urllib.request.urlopen", return_value=mock_pypi_response):
+        versions, url_used = fetch_with_fallback(
+            "requests",
+            index_url="https://primary.example.com/simple/",
+            fallback_url="https://fallback.example.com/simple/",
         )
 
-        with patch("urllib.request.urlopen", side_effect=error):
-            with pytest.raises(PyPIFetchError) as exc_info:
-                fetch_with_fallback(
-                    "nonexistent",
-                    index_url="https://primary.example.com/simple/",
-                    fallback_url="https://fallback.example.com/simple/",
-                )
+    assert len(versions) == 4
+    assert url_used == "https://primary.example.com/simple/"
 
-        assert "primary.example.com" in exc_info.value.url
-        assert isinstance(exc_info.value.original_error, urllib.error.HTTPError)
-        assert exc_info.value.original_error.code == 404
 
-    def test_raises_when_both_fail(self) -> None:
-        """Test that error is raised when both URLs fail."""
-        error = urllib.error.URLError("Connection refused")
+def test_fallback_uses_fallback_on_network_error(
+    mock_pypi_response: MagicMock,
+) -> None:
+    """Test that fallback is used on network error."""
 
-        with patch("urllib.request.urlopen", side_effect=error):
-            with pytest.raises(PyPIFetchError) as exc_info:
-                fetch_with_fallback(
-                    "requests",
-                    index_url="https://primary.example.com/simple/",
-                    fallback_url="https://fallback.example.com/simple/",
-                )
+    def side_effect(request, **kwargs):
+        if "primary" in request.full_url:
+            raise urllib.error.URLError("Connection refused")
+        return mock_pypi_response
 
-        assert "primary.example.com" in exc_info.value.url
-        assert "fallback.example.com" in exc_info.value.url
+    with patch("urllib.request.urlopen", side_effect=side_effect):
+        versions, url_used = fetch_with_fallback(
+            "requests",
+            index_url="https://primary.example.com/simple/",
+            fallback_url="https://fallback.example.com/simple/",
+        )
 
-    def test_no_fallback_raises_on_error(self) -> None:
-        """Test that error is raised when no fallback and primary fails."""
-        error = urllib.error.URLError("Connection refused")
+    assert len(versions) == 4
+    assert url_used == "https://fallback.example.com/simple/"
 
-        with patch("urllib.request.urlopen", side_effect=error):
-            with pytest.raises(PyPIFetchError):
-                fetch_with_fallback(
-                    "requests",
-                    index_url="https://primary.example.com/simple/",
-                    fallback_url=None,
-                )
 
-    def test_uses_default_index_when_none_provided(
-        self, mock_pypi_response: MagicMock
-    ) -> None:
-        """Test that default PyPI is used when no index URL provided."""
-        with patch("urllib.request.urlopen", return_value=mock_pypi_response):
-            versions, url_used = fetch_with_fallback("requests")
+def test_fallback_uses_fallback_on_server_error(mock_pypi_response: MagicMock) -> None:
+    """Test that fallback is used on HTTP 500 error."""
 
-        assert len(versions) == 4
-        assert url_used == "https://pypi.org/simple/"
+    def side_effect(request, **kwargs):
+        if "primary" in request.full_url:
+            raise urllib.error.HTTPError(
+                url=request.full_url,
+                code=500,
+                msg="Internal Server Error",
+                hdrs={},  # type: ignore[arg-type]
+                fp=None,
+            )
+        return mock_pypi_response
+
+    with patch("urllib.request.urlopen", side_effect=side_effect):
+        versions, url_used = fetch_with_fallback(
+            "requests",
+            index_url="https://primary.example.com/simple/",
+            fallback_url="https://fallback.example.com/simple/",
+        )
+
+    assert len(versions) == 4
+    assert url_used == "https://fallback.example.com/simple/"
+
+
+def test_fallback_no_fallback_on_404() -> None:
+    """Test that 404 does NOT trigger fallback."""
+    error = urllib.error.HTTPError(
+        url="https://primary.example.com/simple/nonexistent/",
+        code=404,
+        msg="Not Found",
+        hdrs={},  # type: ignore[arg-type]
+        fp=None,
+    )
+
+    with patch("urllib.request.urlopen", side_effect=error):
+        with pytest.raises(PyPIFetchError) as exc_info:
+            fetch_with_fallback(
+                "nonexistent",
+                index_url="https://primary.example.com/simple/",
+                fallback_url="https://fallback.example.com/simple/",
+            )
+
+    assert "primary.example.com" in exc_info.value.url
+    assert isinstance(exc_info.value.original_error, urllib.error.HTTPError)
+    assert exc_info.value.original_error.code == 404
+
+
+def test_fallback_raises_when_both_fail() -> None:
+    """Test that error is raised when both URLs fail."""
+    error = urllib.error.URLError("Connection refused")
+
+    with patch("urllib.request.urlopen", side_effect=error):
+        with pytest.raises(PyPIFetchError) as exc_info:
+            fetch_with_fallback(
+                "requests",
+                index_url="https://primary.example.com/simple/",
+                fallback_url="https://fallback.example.com/simple/",
+            )
+
+    assert "primary.example.com" in exc_info.value.url
+    assert "fallback.example.com" in exc_info.value.url
+
+
+def test_fallback_no_fallback_raises_on_error() -> None:
+    """Test that error is raised when no fallback and primary fails."""
+    error = urllib.error.URLError("Connection refused")
+
+    with patch("urllib.request.urlopen", side_effect=error):
+        with pytest.raises(PyPIFetchError):
+            fetch_with_fallback(
+                "requests",
+                index_url="https://primary.example.com/simple/",
+                fallback_url=None,
+            )
+
+
+def test_fallback_uses_default_index_when_none_provided(
+    mock_pypi_response: MagicMock,
+) -> None:
+    """Test that default PyPI is used when no index URL provided."""
+    with patch("urllib.request.urlopen", return_value=mock_pypi_response):
+        versions, url_used = fetch_with_fallback("requests")
+
+    assert len(versions) == 4
+    assert url_used == "https://pypi.org/simple/"

--- a/tests/unit/test_sort.py
+++ b/tests/unit/test_sort.py
@@ -167,81 +167,81 @@ def test_sort_case_sensitive() -> None:
     assert result == expected
 
 
-class TestSortRequirementsCommand:
-    """Test sort_requirements CLI command functionality."""
+# =============================================================================
+# sort_requirements CLI command tests
+# =============================================================================
 
-    def test_sort_requirements_file(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test sorting a requirements file."""
-        td = pathlib.Path("/fake/sort-test")
-        td.mkdir(parents=True)
-        requirements_file = td / "requirements.txt"
-        requirements_file.write_text("zpackage\napache\nboto3\n")
 
-        result = cli_runner.invoke(sort_requirements, [str(td)])
-        assert result.exit_code == 0
-        assert "Sorted" in result.output
+def test_sort_requirements_file(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test sorting a requirements file."""
+    td = pathlib.Path("/fake/sort-test")
+    td.mkdir(parents=True)
+    requirements_file = td / "requirements.txt"
+    requirements_file.write_text("zpackage\napache\nboto3\n")
 
-        contents = requirements_file.read_text()
-        assert contents == "apache\nboto3\nzpackage\n"
+    result = cli_runner.invoke(sort_requirements, [str(td)])
+    assert result.exit_code == 0
+    assert "Sorted" in result.output
 
-    def test_sort_already_sorted_file(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test sorting an already sorted requirements file."""
-        td = pathlib.Path("/fake/sort-already-sorted")
-        td.mkdir(parents=True)
-        requirements_file = td / "requirements.txt"
-        requirements_file.write_text("apache\nboto3\nzpackage\n")
+    contents = requirements_file.read_text()
+    assert contents == "apache\nboto3\nzpackage\n"
 
-        result = cli_runner.invoke(sort_requirements, [str(td)])
-        assert result.exit_code == 0
-        assert "already sorted" in result.output
 
-    def test_sort_requirements_with_preview(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test sorting requirements with preview flag."""
-        td = pathlib.Path("/fake/sort-preview")
-        td.mkdir(parents=True)
-        requirements_file = td / "requirements.txt"
-        requirements_file.write_text("zpackage\napache\nboto3\n")
+def test_sort_already_sorted_file(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test sorting an already sorted requirements file."""
+    td = pathlib.Path("/fake/sort-already-sorted")
+    td.mkdir(parents=True)
+    requirements_file = td / "requirements.txt"
+    requirements_file.write_text("apache\nboto3\nzpackage\n")
 
-        result = cli_runner.invoke(sort_requirements, [str(td), "--preview"])
-        assert result.exit_code == 0
-        assert "Previewing changes" in result.output
+    result = cli_runner.invoke(sort_requirements, [str(td)])
+    assert result.exit_code == 0
+    assert "already sorted" in result.output
 
-        # Verify file unchanged
-        contents = requirements_file.read_text()
-        assert contents == "zpackage\napache\nboto3\n"
 
-    def test_sort_removes_comments(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test that sorting removes standalone comments."""
-        td = pathlib.Path("/fake/sort-comments")
-        td.mkdir(parents=True)
-        requirements_file = td / "requirements.txt"
-        requirements_file.write_text("# Header\nzpackage\n# Comment\napache\n")
+def test_sort_requirements_with_preview(
+    cli_runner: CliRunner, fs: FakeFilesystem
+) -> None:
+    """Test sorting requirements with preview flag."""
+    td = pathlib.Path("/fake/sort-preview")
+    td.mkdir(parents=True)
+    requirements_file = td / "requirements.txt"
+    requirements_file.write_text("zpackage\napache\nboto3\n")
 
-        result = cli_runner.invoke(sort_requirements, [str(td)])
-        assert result.exit_code == 0
+    result = cli_runner.invoke(sort_requirements, [str(td), "--preview"])
+    assert result.exit_code == 0
+    assert "Previewing changes" in result.output
 
-        contents = requirements_file.read_text()
-        assert contents == "apache\nzpackage\n"
+    # Verify file unchanged
+    contents = requirements_file.read_text()
+    assert contents == "zpackage\napache\nboto3\n"
 
-    def test_sort_preserves_inline_comments(
-        self, cli_runner: CliRunner, fs: FakeFilesystem
-    ) -> None:
-        """Test that sorting preserves inline comments."""
-        td = pathlib.Path("/fake/sort-inline-comments")
-        td.mkdir(parents=True)
-        requirements_file = td / "requirements.txt"
-        requirements_file.write_text("zpackage==1.0.0  # pinned\napache==2.0.0\n")
 
-        result = cli_runner.invoke(sort_requirements, [str(td)])
-        assert result.exit_code == 0
+def test_sort_removes_comments(cli_runner: CliRunner, fs: FakeFilesystem) -> None:
+    """Test that sorting removes standalone comments."""
+    td = pathlib.Path("/fake/sort-comments")
+    td.mkdir(parents=True)
+    requirements_file = td / "requirements.txt"
+    requirements_file.write_text("# Header\nzpackage\n# Comment\napache\n")
 
-        contents = requirements_file.read_text()
-        assert contents == "apache==2.0.0\nzpackage==1.0.0  # pinned\n"
+    result = cli_runner.invoke(sort_requirements, [str(td)])
+    assert result.exit_code == 0
+
+    contents = requirements_file.read_text()
+    assert contents == "apache\nzpackage\n"
+
+
+def test_sort_command_preserves_inline_comments(
+    cli_runner: CliRunner, fs: FakeFilesystem
+) -> None:
+    """Test that sort command preserves inline comments."""
+    td = pathlib.Path("/fake/sort-inline-comments")
+    td.mkdir(parents=True)
+    requirements_file = td / "requirements.txt"
+    requirements_file.write_text("zpackage==1.0.0  # pinned\napache==2.0.0\n")
+
+    result = cli_runner.invoke(sort_requirements, [str(td)])
+    assert result.exit_code == 0
+
+    contents = requirements_file.read_text()
+    assert contents == "apache==2.0.0\nzpackage==1.0.0  # pinned\n"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,67 +5,81 @@ import pytest
 from requirements.files import gather_requirements_files, resolve_paths
 from requirements.packages import check_package_name
 
-
-class TestGatherRequirementsFiles:
-    """Test functionality when locating requirements.txt files"""
-
-    def test_single_requirements_file(self, single_requirements_file: str) -> None:
-        filepath = pathlib.Path(single_requirements_file)
-        files = gather_requirements_files([filepath])
-        assert len(files) == 1
-
-    def test_multiple_requirements_files(
-        self, multiple_nested_directories: str
-    ) -> None:
-        filepath = pathlib.Path(multiple_nested_directories)
-        files = gather_requirements_files([filepath])
-        assert len(files) == 4
+# =============================================================================
+# gather_requirements_files tests
+# =============================================================================
 
 
-class TestResolvePathsFunction:
-    """Test resolve_paths function"""
+def test_gather_single_requirements_file(single_requirements_file: str) -> None:
+    """Test gathering a single requirements file"""
+    filepath = pathlib.Path(single_requirements_file)
+    files = gather_requirements_files([filepath])
+    assert len(files) == 1
 
-    def test_resolve_single_path(self) -> None:
-        """Test resolving a single path"""
-        result = resolve_paths(("test_path",))
-        assert len(result) == 1
-        assert result[0] == pathlib.Path("test_path")
 
-    def test_resolve_multiple_paths(self) -> None:
-        """Test resolving multiple paths"""
-        result = resolve_paths(("path1", "path2", "path3"))
-        assert len(result) == 3
-        assert result[0] == pathlib.Path("path1")
-        assert result[1] == pathlib.Path("path2")
-        assert result[2] == pathlib.Path("path3")
+def test_gather_multiple_requirements_files(multiple_nested_directories: str) -> None:
+    """Test gathering multiple requirements files from nested directories"""
+    filepath = pathlib.Path(multiple_nested_directories)
+    files = gather_requirements_files([filepath])
+    assert len(files) == 4
 
-    def test_resolve_empty_paths(self) -> None:
-        """Test resolving empty paths defaults to current directory"""
-        result = resolve_paths(())
-        assert len(result) == 1
-        assert result[0] == pathlib.Path.cwd()
 
-    def test_resolve_wildcard_path(self) -> None:
-        """Test resolving wildcard path defaults to current directory"""
-        result = resolve_paths(("*",))
-        assert len(result) == 1
-        assert result[0] == pathlib.Path.cwd()
+# =============================================================================
+# resolve_paths tests
+# =============================================================================
 
-    def test_resolve_paths_with_spaces(self) -> None:
-        """Test resolving paths that contain spaces"""
-        result = resolve_paths(("/path/with spaces/project",))
-        assert len(result) == 1
-        assert result[0] == pathlib.Path("/path/with spaces/project")
 
-    def test_resolve_multiple_paths_with_spaces(self) -> None:
-        """Test resolving multiple paths where some contain spaces"""
-        result = resolve_paths(
-            ("/path/with spaces/project", "/normal/path", "/another path/here")
-        )
-        assert len(result) == 3
-        assert result[0] == pathlib.Path("/path/with spaces/project")
-        assert result[1] == pathlib.Path("/normal/path")
-        assert result[2] == pathlib.Path("/another path/here")
+def test_resolve_single_path() -> None:
+    """Test resolving a single path"""
+    result = resolve_paths(("test_path",))
+    assert len(result) == 1
+    assert result[0] == pathlib.Path("test_path")
+
+
+def test_resolve_multiple_paths() -> None:
+    """Test resolving multiple paths"""
+    result = resolve_paths(("path1", "path2", "path3"))
+    assert len(result) == 3
+    assert result[0] == pathlib.Path("path1")
+    assert result[1] == pathlib.Path("path2")
+    assert result[2] == pathlib.Path("path3")
+
+
+def test_resolve_empty_paths() -> None:
+    """Test resolving empty paths defaults to current directory"""
+    result = resolve_paths(())
+    assert len(result) == 1
+    assert result[0] == pathlib.Path.cwd()
+
+
+def test_resolve_wildcard_path() -> None:
+    """Test resolving wildcard path defaults to current directory"""
+    result = resolve_paths(("*",))
+    assert len(result) == 1
+    assert result[0] == pathlib.Path.cwd()
+
+
+def test_resolve_paths_with_spaces() -> None:
+    """Test resolving paths that contain spaces"""
+    result = resolve_paths(("/path/with spaces/project",))
+    assert len(result) == 1
+    assert result[0] == pathlib.Path("/path/with spaces/project")
+
+
+def test_resolve_multiple_paths_with_spaces() -> None:
+    """Test resolving multiple paths where some contain spaces"""
+    result = resolve_paths(
+        ("/path/with spaces/project", "/normal/path", "/another path/here")
+    )
+    assert len(result) == 3
+    assert result[0] == pathlib.Path("/path/with spaces/project")
+    assert result[1] == pathlib.Path("/normal/path")
+    assert result[2] == pathlib.Path("/another path/here")
+
+
+# =============================================================================
+# check_package_name tests
+# =============================================================================
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Add support for configuring default PyPI index URL and fallback URL in user configuration
- Add `config unset` command to remove settings
- Update `config set` syntax to use `section.key` format for consistency
- Refactor tests to use pyfakefs consistently and reduce duplication

## Changes

### New Configuration Options

```toml
# ~/.requirements/config.toml
[pypi]
index_url = "https://nexus.example.com/simple/"
fallback_url = "https://pypi.org/simple/"
```

### New Commands

```bash
# Set PyPI index URL
requirements config set pypi.index_url https://nexus.example.com/simple/

# Set fallback URL
requirements config set pypi.fallback_url https://pypi.org/simple/

# Remove a setting (reset to default)
requirements config unset pypi.index_url
```

### Fallback Behavior

- Primary URL is tried first
- On network/server errors: falls back to `pypi.fallback_url` if configured
- On 404: does NOT fallback (package doesn't exist)

### Index URL Priority

1. `--index-url` CLI flag (highest)
2. Config `pypi.index_url`
3. Default PyPI (`https://pypi.org/simple/`)

## Breaking Changes

The `config set` syntax changed from positional to dot-notation:

```bash
# Old (no longer works)
requirements config set color true

# New
requirements config set color.enabled true
```

## Test Plan

- [x] All 316 tests pass
- [x] 94.40% code coverage maintained
- [x] Linting passes (ruff)
- [x] Type checking passes (ty)
- [x] Unit tests for new config functions
- [x] Unit tests for `fetch_with_fallback()` 
- [x] Integration tests for `config set` and `config unset`
- [x] Integration tests for versions command with config